### PR TITLE
[fix] (all) explicit omit of hdKey in PublicConfig

### DIFF
--- a/packages/ripple-payments/src/BaseRipplePayments.ts
+++ b/packages/ripple-payments/src/BaseRipplePayments.ts
@@ -63,7 +63,7 @@ export abstract class BaseRipplePayments<Config extends BaseRipplePaymentsConfig
 
   getPublicConfig() {
     return {
-      ...omit(this.config, ['logger', 'server']),
+      ...omit(this.config, ['logger', 'server', 'hdKey']),
       ...this.getPublicAccountConfig(),
     }
   }

--- a/packages/stellar-payments/src/BaseStellarPayments.ts
+++ b/packages/stellar-payments/src/BaseStellarPayments.ts
@@ -59,7 +59,7 @@ export abstract class BaseStellarPayments<Config extends BaseStellarPaymentsConf
 
   getPublicConfig() {
     return {
-      ...omit(this.config, ['logger', 'server']),
+      ...omit(this.config, ['logger', 'server', 'hdKey']),
       ...this.getPublicAccountConfig(),
     }
   }

--- a/packages/tron-payments/src/HdTronPayments.ts
+++ b/packages/tron-payments/src/HdTronPayments.ts
@@ -34,7 +34,7 @@ export class HdTronPayments extends BaseTronPayments<HdTronPaymentsConfig> {
 
   getPublicConfig(): HdTronPaymentsConfig {
     return {
-      ...omit(this.config, ['logger', 'fullNode', 'solidityNode', 'eventServer']),
+      ...omit(this.config, ['logger', 'fullNode', 'solidityNode', 'eventServer', 'hdKey']),
       hdKey: this.getXpub(),
     }
   }


### PR DESCRIPTION
Flipping the lines in the returned object will leak of extended private key as public key will be overwritten by `hdKey` property from config.

Add explicit omission of `hdKey` property to avoid accidental private key exposure