### PR TITLE
[fix] (ethereum) throw appropriate error on nonce too low

### DIFF
--- a/packages/ethereum-payments/src/BaseEthereumPayments.ts
+++ b/packages/ethereum-payments/src/BaseEthereumPayments.ts
@@ -319,6 +319,9 @@ implements BasePayments
       }
     } catch (e) {
       this.logger.warn(`Ethereum broadcast tx unsuccessful ${tx.id}: ${e.message}`)
+      if (e.message === 'nonce too low') {
+        throw new PaymentsError(PaymentsErrorCode.TxSequenceCollision, e.message)
+      }
       throw new Error(`Ethereum broadcast tx unsuccessful: ${tx.id} ${e.message}`)
     }
   }


### PR DESCRIPTION
Signed-off-by: Denys Bitaccess <denys@bitaccess.co>

Ethrereum nodes do not throw an error if nonce is too high. Transaction is simply unavailable after transmition
