### PR TITLE
[feature] (common) optional block number in tx info

### DIFF
--- a/packages/payments-common/src/types.ts
+++ b/packages/payments-common/src/types.ts
@@ -233,7 +233,8 @@ export const BaseTransactionInfo = extendCodec(
     data: t.object,
   },
   {
-    confirmationNumber: t.union([t.string, t.number]) // eg block number
+    currentBlockNumber: t.union([t.string, t.number]), // latest head of the blockchain
+    confirmationNumber: t.union([t.string, t.number]) // eg block number in which tx was included
   },
   'BaseTransactionInfo',
 )


### PR DESCRIPTION
allow optional return of current head of blockchain in `BaseTransactionInfo`
