### PR TITLE
Standardize getBalance behaviour for unused addresses

### DIFF
--- a/packages/bitcoin-payments/package-lock.json
+++ b/packages/bitcoin-payments/package-lock.json
@@ -241,16 +241,6 @@
         "minimist": "^1.2.0"
       }
     },
-    "@faast/payments-common": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@faast/payments-common/-/payments-common-2.1.2.tgz",
-      "integrity": "sha512-u3IBaAzIoY4iRlpn0b9FDcVLtETBOoPIdR9kPerPE5dVYtSwBwLJ5RO2ieZUwtyw/4NtzayGulyJ2UHWBDyMrg==",
-      "requires": {
-        "@faast/ts-common": "^0.6.0",
-        "bignumber.js": "^9.0.0",
-        "io-ts": "^1.10.4"
-      }
-    },
     "@faast/ts-common": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/@faast/ts-common/-/ts-common-0.6.0.tgz",

--- a/packages/bitcoin-payments/src/bitcoinish/BitcoinishPayments.ts
+++ b/packages/bitcoin-payments/src/bitcoinish/BitcoinishPayments.ts
@@ -144,13 +144,16 @@ export abstract class BitcoinishPayments<Config extends BaseConfig> extends Bitc
   async getBalance(payport: ResolveablePayport): Promise<BalanceResult> {
     const { address } = await this.resolvePayport(payport)
     const result = await this._retryDced(() => this.getApi().getAddressDetails(address, { details: 'basic' }))
-    const confirmedBalance = this.toMainDenominationString(result.balance)
-    const unconfirmedBalance = this.toMainDenominationString(result.unconfirmedBalance)
+    const confirmedBalance = this.toMainDenominationBigNumber(result.balance)
+    const unconfirmedBalance = this.toMainDenominationBigNumber(result.unconfirmedBalance)
+    const spendableBalance = confirmedBalance.plus(unconfirmedBalance)
     this.logger.debug('getBalance', address, confirmedBalance, unconfirmedBalance)
     return {
-      confirmedBalance,
-      unconfirmedBalance,
-      sweepable: this.isSweepableBalance(confirmedBalance)
+      confirmedBalance: confirmedBalance.toString(),
+      unconfirmedBalance: unconfirmedBalance.toString(),
+      spendableBalance: spendableBalance.toString(),
+      sweepable: this.isSweepableBalance(spendableBalance),
+      unactivated: false,
     }
   }
 

--- a/packages/bitcoin-payments/src/bitcoinish/BitcoinishPayments.ts
+++ b/packages/bitcoin-payments/src/bitcoinish/BitcoinishPayments.ts
@@ -153,7 +153,7 @@ export abstract class BitcoinishPayments<Config extends BaseConfig> extends Bitc
       unconfirmedBalance: unconfirmedBalance.toString(),
       spendableBalance: spendableBalance.toString(),
       sweepable: this.isSweepableBalance(spendableBalance),
-      unactivated: false,
+      requiresActivation: false,
     }
   }
 

--- a/packages/bitcoin-payments/test/HdBitcoinPayments.test.ts
+++ b/packages/bitcoin-payments/test/HdBitcoinPayments.test.ts
@@ -295,7 +295,7 @@ function runHardcodedPublicKeyTests(
       unconfirmedBalance: '0',
       spendableBalance: '0',
       sweepable: false,
-      unactivated: false,
+      requiresActivation: false,
     })
   })
   it('get a balance using an address', async () => {
@@ -304,7 +304,7 @@ function runHardcodedPublicKeyTests(
       unconfirmedBalance: '0',
       spendableBalance: '0',
       sweepable: false,
-      unactivated: false,
+      requiresActivation: false,
     })
   })
 }

--- a/packages/bitcoin-payments/test/HdBitcoinPayments.test.ts
+++ b/packages/bitcoin-payments/test/HdBitcoinPayments.test.ts
@@ -293,14 +293,18 @@ function runHardcodedPublicKeyTests(
     expect(await payments.getBalance(1)).toEqual({
       confirmedBalance: '0',
       unconfirmedBalance: '0',
+      spendableBalance: '0',
       sweepable: false,
+      unactivated: false,
     })
   })
   it('get a balance using an address', async () => {
     expect(await payments.getBalance({ address: addresses[0] })).toEqual({
       confirmedBalance: '0',
       unconfirmedBalance: '0',
+      spendableBalance: '0',
       sweepable: false,
+      unactivated: false,
     })
   })
 }

--- a/packages/bitcoin-payments/test/e2e.mainnet.test.ts
+++ b/packages/bitcoin-payments/test/e2e.mainnet.test.ts
@@ -81,21 +81,37 @@ describeAll('e2e mainnet', () => {
     expect(await payments.getBalance(0)).toEqual({
       confirmedBalance: address0balance,
       unconfirmedBalance: '0',
+      spendableBalance: address0balance,
       sweepable: true,
+      unactivated: false,
     })
   })
   it('get correct balance for address 0', async () => {
     expect(await payments.getBalance({ address: address0 })).toEqual({
       confirmedBalance: address0balance,
       unconfirmedBalance: '0',
+      spendableBalance: address0balance,
       sweepable: true,
+      unactivated: false,
     })
   })
   it('get correct balance for address 3', async () => {
     expect(await payments.getBalance({ address: address3 })).toEqual({
       confirmedBalance: '0',
       unconfirmedBalance: '0',
+      spendableBalance: '0',
       sweepable: false,
+      unactivated: false,
+    })
+  })
+
+  it('can get balance of unused address', async () => {
+    expect(await payments.getBalance(12345678)).toEqual({
+      confirmedBalance: '0',
+      unconfirmedBalance: '0',
+      spendableBalance: '0',
+      sweepable: false,
+      unactivated: false,
     })
   })
 

--- a/packages/bitcoin-payments/test/e2e.mainnet.test.ts
+++ b/packages/bitcoin-payments/test/e2e.mainnet.test.ts
@@ -83,7 +83,7 @@ describeAll('e2e mainnet', () => {
       unconfirmedBalance: '0',
       spendableBalance: address0balance,
       sweepable: true,
-      unactivated: false,
+      requiresActivation: false,
     })
   })
   it('get correct balance for address 0', async () => {
@@ -92,7 +92,7 @@ describeAll('e2e mainnet', () => {
       unconfirmedBalance: '0',
       spendableBalance: address0balance,
       sweepable: true,
-      unactivated: false,
+      requiresActivation: false,
     })
   })
   it('get correct balance for address 3', async () => {
@@ -101,7 +101,7 @@ describeAll('e2e mainnet', () => {
       unconfirmedBalance: '0',
       spendableBalance: '0',
       sweepable: false,
-      unactivated: false,
+      requiresActivation: false,
     })
   })
 
@@ -111,7 +111,7 @@ describeAll('e2e mainnet', () => {
       unconfirmedBalance: '0',
       spendableBalance: '0',
       sweepable: false,
-      unactivated: false,
+      requiresActivation: false,
     })
   })
 

--- a/packages/bitcoin-payments/test/e2e.testnet.multisig.test.ts
+++ b/packages/bitcoin-payments/test/e2e.testnet.multisig.test.ts
@@ -127,6 +127,15 @@ describeAll('e2e multisig testnet', () => {
         expect(address).toBe(address0)
       })
 
+      it('can get balance', async () => {
+        const balanceResult = await payments.getBalance(0)
+        expect(balanceResult.confirmedBalance).toBeTruthy()
+        expect(balanceResult.confirmedBalance).toBeTruthy()
+        expect(balanceResult.spendableBalance).toBeTruthy()
+        expect(balanceResult.sweepable).toBe(true)
+        expect(balanceResult.unactivated).toBe(false)
+      })
+
       it('can create sweep', async () => {
         const tx = await payments.createSweepTransaction(0, EXTERNAL_ADDRESS)
         expect(tx.multisigData).toBeDefined()

--- a/packages/bitcoin-payments/test/e2e.testnet.multisig.test.ts
+++ b/packages/bitcoin-payments/test/e2e.testnet.multisig.test.ts
@@ -133,7 +133,7 @@ describeAll('e2e multisig testnet', () => {
         expect(balanceResult.confirmedBalance).toBeTruthy()
         expect(balanceResult.spendableBalance).toBeTruthy()
         expect(balanceResult.sweepable).toBe(true)
-        expect(balanceResult.unactivated).toBe(false)
+        expect(balanceResult.requiresActivation).toBe(false)
       })
 
       it('can create sweep', async () => {

--- a/packages/bitcoin-payments/test/e2e.testnet.test.ts
+++ b/packages/bitcoin-payments/test/e2e.testnet.test.ts
@@ -122,7 +122,11 @@ describeAll('e2e testnet', () => {
           throw new Error(`Cannot end to end test sweeping due to lack of funds. Send testnet BTC to any of the following addresses and try again. ${JSON.stringify(allAddresses)}`)
         }
         const recipientIndex = indexToSweep === indicesToTry[0] ? indicesToTry[1] : indicesToTry[0]
-        const unsignedTx = await payments.createSweepTransaction(indexToSweep, recipientIndex)
+        const unsignedTx = await payments.createSweepTransaction(
+          indexToSweep,
+          recipientIndex,
+          { useUnconfirmedUtxos: true }, // Prevents consecutive tests from failing
+        )
         const signedTx = await payments.signTransaction(unsignedTx)
         logger.log(`Sweeping ${signedTx.amount} from ${indexToSweep} to ${recipientIndex} in tx ${signedTx.id}`)
         expect(await payments.broadcastTransaction(signedTx)).toEqual({
@@ -152,7 +156,12 @@ describeAll('e2e testnet', () => {
           throw new Error(`Cannot end to end test sweeping due to lack of funds. Send testnet BTC to any of the following addresses and try again. ${JSON.stringify(allAddresses)}`)
         }
         const recipientIndex = indexToSend === indicesToTry[0] ? indicesToTry[1] : indicesToTry[0]
-        const unsignedTx = await payments.createTransaction(indexToSend, recipientIndex, '0.0001')
+        const unsignedTx = await payments.createTransaction(
+          indexToSend,
+          recipientIndex,
+          '0.0001',
+          { useUnconfirmedUtxos: true }, // Prevents consecutive tests from failing
+        )
         const signedTx = await payments.signTransaction(unsignedTx)
         logger.log(`Sending ${signedTx.amount} from ${indexToSend} to ${recipientIndex} in tx ${signedTx.id}`)
         expect(await payments.broadcastTransaction(signedTx)).toEqual({

--- a/packages/ethereum-payments/package-lock.json
+++ b/packages/ethereum-payments/package-lock.json
@@ -241,16 +241,6 @@
         "minimist": "^1.2.0"
       }
     },
-    "@faast/payments-common": {
-      "version": "2.1.13",
-      "resolved": "https://registry.npmjs.org/@faast/payments-common/-/payments-common-2.1.13.tgz",
-      "integrity": "sha512-zj85OHR9CQYQnSaaKEPlVmxvGI+Gk/U/v3kFxiOJ5/TKob9phik0O3TtZkBdlnDEu7HLbga9PhVLZUCjrDQaFA==",
-      "requires": {
-        "@faast/ts-common": "^0.6.0",
-        "bignumber.js": "^9.0.0",
-        "io-ts": "^1.10.4"
-      }
-    },
     "@faast/ts-common": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/@faast/ts-common/-/ts-common-0.6.0.tgz",
@@ -3132,7 +3122,8 @@
           "version": "2.1.1",
           "resolved": false,
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3156,13 +3147,15 @@
           "version": "1.0.0",
           "resolved": false,
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "resolved": false,
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3179,19 +3172,22 @@
           "version": "1.1.0",
           "resolved": false,
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "resolved": false,
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "resolved": false,
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3322,7 +3318,8 @@
           "version": "2.0.4",
           "resolved": false,
           "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3336,6 +3333,7 @@
           "resolved": false,
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3352,6 +3350,7 @@
           "resolved": false,
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3360,13 +3359,15 @@
           "version": "0.0.8",
           "resolved": false,
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.9.0",
           "resolved": false,
           "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -3387,6 +3388,7 @@
           "resolved": false,
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3485,7 +3487,8 @@
           "version": "1.0.1",
           "resolved": false,
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3499,6 +3502,7 @@
           "resolved": false,
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3594,7 +3598,8 @@
           "version": "5.1.2",
           "resolved": false,
           "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3636,6 +3641,7 @@
           "resolved": false,
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3657,6 +3663,7 @@
           "resolved": false,
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3705,13 +3712,15 @@
           "version": "1.0.2",
           "resolved": false,
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.1.1",
           "resolved": false,
           "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -3976,6 +3985,7 @@
           "resolved": "https://registry.npmjs.org/@types/bignumber.js/-/bignumber.js-5.0.0.tgz",
           "integrity": "sha512-0DH7aPGCClywOFaxxjE6UwpN2kQYe9LwuDQMv+zYA97j5GkOMo8e66LYT+a8JYU7jfmUFRZLa9KycxHDsKXJCA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "bignumber.js": "*"
           }
@@ -4039,6 +4049,7 @@
           "resolved": "https://registry.npmjs.org/@web3-js/websocket/-/websocket-1.0.30.tgz",
           "integrity": "sha512-fDwrD47MiDrzcJdSeTLF75aCcxVVt8B1N74rA+vh2XCAvFy4tEWJjtnUtj2QG7/zlQ6g9cQ88bZFBxwd9/FmtA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "debug": "^2.2.0",
             "es5-ext": "^0.10.50",
@@ -4052,6 +4063,7 @@
               "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
               "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
               "dev": true,
+              "optional": true,
               "requires": {
                 "ms": "2.0.0"
               }
@@ -4060,13 +4072,15 @@
               "version": "2.0.0",
               "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
               "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "nan": {
               "version": "2.14.0",
               "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
               "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
-              "dev": true
+              "dev": true,
+              "optional": true
             }
           }
         },
@@ -4368,7 +4382,8 @@
           "version": "1.3.0",
           "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
           "integrity": "sha1-q8av7tzqUugJzcA3au0845Y10X8=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "anymatch": {
           "version": "2.0.0",
@@ -5478,7 +5493,8 @@
           "version": "9.0.0",
           "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.0.tgz",
           "integrity": "sha512-t/OYhhJ2SD+YGBQcjY8GzzDHEk9f3nerxjtfa6tlMXfe7frs/WozhvCNoGvpM0P3bNf3Gq5ZRMlGr5f3r4/N8A==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "binary-extensions": {
           "version": "1.13.1",
@@ -5519,6 +5535,7 @@
           "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
           "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "readable-stream": "^2.3.5",
             "safe-buffer": "^5.1.1"
@@ -5539,6 +5556,7 @@
           "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.0.tgz",
           "integrity": "sha512-dhEPs72UPbDnAQJ9ZKMNTP6ptJaionhP5cBb541nXPlW60Jepo9RV/a4fX4XWW9CuFNK22krhrj1+rgzifNCsw==",
           "dev": true,
+          "optional": true,
           "requires": {
             "bytes": "3.1.0",
             "content-type": "~1.0.4",
@@ -5557,6 +5575,7 @@
               "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
               "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
               "dev": true,
+              "optional": true,
               "requires": {
                 "ms": "2.0.0"
               }
@@ -5565,7 +5584,8 @@
               "version": "2.0.0",
               "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
               "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-              "dev": true
+              "dev": true,
+              "optional": true
             }
           }
         },
@@ -5746,6 +5766,7 @@
           "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
           "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
           "dev": true,
+          "optional": true,
           "requires": {
             "buffer-alloc-unsafe": "^1.1.0",
             "buffer-fill": "^1.0.0"
@@ -5755,7 +5776,8 @@
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
           "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "buffer-crc32": {
           "version": "0.2.13",
@@ -5774,7 +5796,8 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
           "integrity": "sha1-+PeLdniYiO858gXNY39o5wISKyw=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "buffer-from": {
           "version": "1.1.1",
@@ -5785,7 +5808,8 @@
           "version": "0.0.5",
           "resolved": "https://registry.npmjs.org/buffer-to-arraybuffer/-/buffer-to-arraybuffer-0.0.5.tgz",
           "integrity": "sha1-YGSkD6dutDxyOrqe+PbhIW0QURo=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "buffer-xor": {
           "version": "1.0.3",
@@ -5801,7 +5825,8 @@
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
           "integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "bytewise": {
           "version": "1.1.0",
@@ -6338,7 +6363,8 @@
           "version": "1.0.4",
           "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
           "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "convert-source-map": {
           "version": "1.6.0",
@@ -6373,7 +6399,8 @@
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.2.tgz",
           "integrity": "sha512-Mw+adcfzPxcPeI+0WlvRrr/3lGVO0bD75SxX6811cxSh1Wbxx7xZBGK1eVtDf6si8rg2lhnUjsVLMFMfbRIuwA==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "copy-concurrently": {
           "version": "1.0.5",
@@ -6665,6 +6692,7 @@
           "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
           "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
           "dev": true,
+          "optional": true,
           "requires": {
             "mimic-response": "^1.0.0"
           }
@@ -6674,6 +6702,7 @@
           "resolved": "https://registry.npmjs.org/decompress-tar/-/decompress-tar-4.1.1.tgz",
           "integrity": "sha512-JdJMaCrGpB5fESVyxwpCx4Jdj2AagLmv3y58Qy4GE6HMVjWz1FeVQk1Ct4Kye7PftcdOo/7U7UKzYBJgqnGeUQ==",
           "dev": true,
+          "optional": true,
           "requires": {
             "file-type": "^5.2.0",
             "is-stream": "^1.1.0",
@@ -6925,7 +6954,8 @@
           "version": "1.1.2",
           "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
           "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "des.js": {
           "version": "1.0.0",
@@ -6940,7 +6970,8 @@
           "version": "1.0.4",
           "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
           "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "detect-file": {
           "version": "1.0.0",
@@ -7005,7 +7036,8 @@
           "version": "0.1.4",
           "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
           "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "duplexify": {
           "version": "3.7.1",
@@ -7041,7 +7073,8 @@
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
           "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "electron-to-chromium": {
           "version": "1.3.237",
@@ -7082,7 +7115,8 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
           "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "encoding": {
           "version": "0.1.12",
@@ -7236,7 +7270,8 @@
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
           "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "escape-string-regexp": {
           "version": "1.0.5",
@@ -7596,7 +7631,8 @@
           "version": "1.8.1",
           "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
           "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "eth-block-tracker": {
           "version": "3.0.1",
@@ -8099,6 +8135,7 @@
           "resolved": "https://registry.npmjs.org/ethereum-bloom-filters/-/ethereum-bloom-filters-1.0.6.tgz",
           "integrity": "sha512-dE9CGNzgOOsdh7msZirvv8qjHtnHpvBlKe2647kM8v+yeF71IRso55jpojemvHV+jMjr48irPWxMRaHuOWzAFA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "js-sha3": "^0.8.0"
           },
@@ -8107,7 +8144,8 @@
               "version": "0.8.0",
               "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
               "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==",
-              "dev": true
+              "dev": true,
+              "optional": true
             }
           }
         },
@@ -8338,6 +8376,7 @@
           "resolved": "https://registry.npmjs.org/ethjs-unit/-/ethjs-unit-0.1.6.tgz",
           "integrity": "sha1-xmWSHkduh7ziqdWIpv4EBbLEFpk=",
           "dev": true,
+          "optional": true,
           "requires": {
             "bn.js": "4.11.6",
             "number-to-bn": "1.7.0"
@@ -8347,7 +8386,8 @@
               "version": "4.11.6",
               "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
               "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU=",
-              "dev": true
+              "dev": true,
+              "optional": true
             }
           }
         },
@@ -8364,7 +8404,8 @@
           "version": "3.1.2",
           "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
           "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "events": {
           "version": "3.0.0",
@@ -8714,7 +8755,8 @@
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/file-type/-/file-type-5.2.0.tgz",
           "integrity": "sha1-LdvqfHP/42No365J3DOMBYwritY=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "file-uri-to-path": {
           "version": "1.0.0",
@@ -9022,7 +9064,8 @@
           "version": "0.5.2",
           "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
           "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "from2": {
           "version": "2.3.0",
@@ -9037,7 +9080,8 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
           "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "fs-extra": {
           "version": "4.0.3",
@@ -9104,7 +9148,8 @@
             },
             "ansi-regex": {
               "version": "2.1.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -9122,11 +9167,13 @@
             },
             "balanced-match": {
               "version": "1.0.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -9139,15 +9186,18 @@
             },
             "code-point-at": {
               "version": "1.1.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "concat-map": {
               "version": "0.0.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -9250,7 +9300,8 @@
             },
             "inherits": {
               "version": "2.0.3",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "ini": {
               "version": "1.3.5",
@@ -9260,6 +9311,7 @@
             "is-fullwidth-code-point": {
               "version": "1.0.0",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -9272,17 +9324,20 @@
             "minimatch": {
               "version": "3.0.4",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
             },
             "minimist": {
               "version": "0.0.8",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -9299,6 +9354,7 @@
             "mkdirp": {
               "version": "0.5.1",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -9371,7 +9427,8 @@
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -9381,6 +9438,7 @@
             "once": {
               "version": "1.4.0",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -9456,7 +9514,8 @@
             },
             "safe-buffer": {
               "version": "5.1.2",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -9486,6 +9545,7 @@
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -9503,6 +9563,7 @@
             "strip-ansi": {
               "version": "3.0.1",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -9541,11 +9602,13 @@
             },
             "wrappy": {
               "version": "1.0.2",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "yallist": {
               "version": "3.0.3",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             }
           }
         },
@@ -10023,6 +10086,7 @@
           "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.2.tgz",
           "integrity": "sha512-uUQBt3H/cSIVfch6i1EuPNy/YsRSOUBXTVfZ+yR7Zjez3qjBz6i9+i4zjNaoqcoFVI4lQJ5plg63TvGfRSDCRg==",
           "dev": true,
+          "optional": true,
           "requires": {
             "depd": "~1.1.2",
             "inherits": "2.0.3",
@@ -10035,7 +10099,8 @@
               "version": "2.0.3",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
               "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-              "dev": true
+              "dev": true,
+              "optional": true
             }
           }
         },
@@ -10043,7 +10108,8 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/http-https/-/http-https-1.0.0.tgz",
           "integrity": "sha1-L5CN1fHbQGjAWM1ubUzjkskTOJs=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "http-signature": {
           "version": "1.2.0",
@@ -11781,7 +11847,8 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
           "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "lru-cache": {
           "version": "3.2.0",
@@ -11905,7 +11972,8 @@
           "version": "0.3.0",
           "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
           "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "memdown": {
           "version": "1.4.1",
@@ -12082,7 +12150,8 @@
           "version": "1.6.0",
           "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
           "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "mime-db": {
           "version": "1.40.0",
@@ -12106,7 +12175,8 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
           "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "min-document": {
           "version": "2.19.0",
@@ -12145,6 +12215,7 @@
           "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
           "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -12546,6 +12617,7 @@
           "resolved": "https://registry.npmjs.org/number-to-bn/-/number-to-bn-1.7.0.tgz",
           "integrity": "sha1-uzYjWS9+X54AMLGXe9QaDFP+HqA=",
           "dev": true,
+          "optional": true,
           "requires": {
             "bn.js": "4.11.6",
             "strip-hex-prefix": "1.0.0"
@@ -12555,7 +12627,8 @@
               "version": "4.11.6",
               "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
               "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU=",
-              "dev": true
+              "dev": true,
+              "optional": true
             }
           }
         },
@@ -12900,6 +12973,7 @@
           "resolved": "https://registry.npmjs.org/oboe/-/oboe-2.1.4.tgz",
           "integrity": "sha1-IMiM2wwVNxuwQRklfU/dNLCqSfY=",
           "dev": true,
+          "optional": true,
           "requires": {
             "http-https": "^1.0.0"
           }
@@ -12909,6 +12983,7 @@
           "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
           "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
           "dev": true,
+          "optional": true,
           "requires": {
             "ee-first": "1.1.1"
           }
@@ -13133,7 +13208,8 @@
           "version": "1.3.3",
           "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
           "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "pascalcase": {
           "version": "0.1.1",
@@ -13535,13 +13611,15 @@
           "version": "6.7.0",
           "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
           "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "query-string": {
           "version": "5.1.1",
           "resolved": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
           "integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
           "dev": true,
+          "optional": true,
           "requires": {
             "decode-uri-component": "^0.2.0",
             "object-assign": "^4.1.0",
@@ -13579,13 +13657,15 @@
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
           "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "raw-body": {
           "version": "2.4.0",
           "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.0.tgz",
           "integrity": "sha512-4Oz8DUIwdvoa5qMJelxipzi/iJIi40O5cGV1wNYp5hvZP8ZN0T+jiNkL0QepXs+EsQ9XJ8ipEDoiH70ySUJP3Q==",
           "dev": true,
+          "optional": true,
           "requires": {
             "bytes": "3.1.0",
             "http-errors": "1.7.2",
@@ -14054,7 +14134,8 @@
           "version": "2.0.3",
           "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-2.0.3.tgz",
           "integrity": "sha1-uwBAvgMEPamgEqLOqfyfhSz8h9Q=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "scrypt.js": {
           "version": "0.3.0",
@@ -14145,6 +14226,7 @@
           "resolved": "https://registry.npmjs.org/send/-/send-0.17.1.tgz",
           "integrity": "sha512-BsVKsiGcQMFwT8UxypobUKyv7irCNRHk1T0G680vk88yf6LBByGcZJOTJCrTP2xVN6yI+XjPJcNuE3V4fT9sAg==",
           "dev": true,
+          "optional": true,
           "requires": {
             "debug": "2.6.9",
             "depd": "~1.1.2",
@@ -14166,6 +14248,7 @@
               "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
               "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
               "dev": true,
+              "optional": true,
               "requires": {
                 "ms": "2.0.0"
               },
@@ -14174,7 +14257,8 @@
                   "version": "2.0.0",
                   "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
                   "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-                  "dev": true
+                  "dev": true,
+                  "optional": true
                 }
               }
             },
@@ -14182,7 +14266,8 @@
               "version": "2.1.1",
               "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
               "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
-              "dev": true
+              "dev": true,
+              "optional": true
             }
           }
         },
@@ -14259,7 +14344,8 @@
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
           "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "sha.js": {
           "version": "2.4.11",
@@ -14301,13 +14387,15 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.0.tgz",
           "integrity": "sha1-c0TLuLbib7J9ZrL8hvn21Zl1IcY=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "simple-get": {
           "version": "2.8.1",
           "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-2.8.1.tgz",
           "integrity": "sha512-lSSHRSw3mQNUGPAYRqo7xy9dhKmxFXIjLjp4KHpf99GEH2VH7C3AM+Qfx6du6jhfUi6Vm7XnbEVEf7Wb6N8jRw==",
           "dev": true,
+          "optional": true,
           "requires": {
             "decompress-response": "^3.3.0",
             "once": "^1.3.1",
@@ -14694,7 +14782,8 @@
           "version": "1.5.0",
           "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
           "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "stream-browserify": {
           "version": "2.0.2",
@@ -14759,7 +14848,8 @@
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
           "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "string-argv": {
           "version": "0.0.2",
@@ -15071,6 +15161,7 @@
           "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.2.tgz",
           "integrity": "sha512-rzS0heiNf8Xn7/mpdSVVSMAWAoy9bfb1WOTYC78Z0UQKeKa/CWS8FOq0lKGNa8DWKAn9gxjCvMLYc5PGXYlK2A==",
           "dev": true,
+          "optional": true,
           "requires": {
             "bl": "^1.0.0",
             "buffer-alloc": "^1.2.0",
@@ -15288,7 +15379,8 @@
           "version": "4.0.1",
           "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
           "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "timers-browserify": {
           "version": "2.0.11",
@@ -15326,7 +15418,8 @@
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.1.1.tgz",
           "integrity": "sha512-lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "to-fast-properties": {
           "version": "1.0.3",
@@ -15392,7 +15485,8 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
           "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "toposort": {
           "version": "2.0.2",
@@ -15474,6 +15568,7 @@
           "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
           "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
           "dev": true,
+          "optional": true,
           "requires": {
             "media-typer": "0.3.0",
             "mime-types": "~2.1.24"
@@ -15683,7 +15778,8 @@
           "version": "1.9.1",
           "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.1.tgz",
           "integrity": "sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "undertaker": {
           "version": "1.2.1",
@@ -15762,7 +15858,8 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
           "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "unset-value": {
           "version": "1.0.0",
@@ -15853,7 +15950,8 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/url-set-query/-/url-set-query-1.0.0.tgz",
           "integrity": "sha1-AW6M/Xwg7gXK/neV6JK9BwL6ozk=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "url-to-options": {
           "version": "1.0.1",
@@ -15871,7 +15969,8 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/utf8/-/utf8-3.0.0.tgz",
           "integrity": "sha512-E8VjFIQ/TyQgp+TZfS6l8yp/xWppSAHzidGiRrqe4bK4XP9pTRyKFgGJpO3SN7zdX4DeomTrwaseCHovfpFcqQ==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "util": {
           "version": "0.10.3",
@@ -15948,7 +16047,8 @@
           "version": "1.1.2",
           "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
           "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "verror": {
           "version": "1.10.0",
@@ -16073,6 +16173,7 @@
           "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.2.4.tgz",
           "integrity": "sha512-CHc27sMuET2cs1IKrkz7xzmTdMfZpYswe7f0HcuyneTwS1yTlTnHyqjAaTy0ZygAb/x4iaVox+Gvr4oSAqSI+A==",
           "dev": true,
+          "optional": true,
           "requires": {
             "@types/bignumber.js": "^5.0.0",
             "@types/bn.js": "^4.11.4",
@@ -16087,7 +16188,8 @@
               "version": "12.12.14",
               "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.14.tgz",
               "integrity": "sha512-u/SJDyXwuihpwjXy7hOOghagLEV1KdAST6syfnOk6QZAMzZuWZqXy5aYYZbh8Jdpd4escVFP0MvftHNDb9pruA==",
-              "dev": true
+              "dev": true,
+              "optional": true
             }
           }
         },
@@ -16096,6 +16198,7 @@
           "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.2.4.tgz",
           "integrity": "sha512-U7wbsK8IbZvF3B7S+QMSNP0tni/6VipnJkB0tZVEpHEIV2WWeBHYmZDnULWcsS/x/jn9yKhJlXIxWGsEAMkjiw==",
           "dev": true,
+          "optional": true,
           "requires": {
             "underscore": "1.9.1",
             "web3-eth-iban": "1.2.4",
@@ -16107,6 +16210,7 @@
           "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.2.4.tgz",
           "integrity": "sha512-8p9kpL7di2qOVPWgcM08kb+yKom0rxRCMv6m/K+H+yLSxev9TgMbCgMSbPWAHlyiF3SJHw7APFKahK5Z+8XT5A==",
           "dev": true,
+          "optional": true,
           "requires": {
             "underscore": "1.9.1",
             "web3-core-helpers": "1.2.4",
@@ -16120,6 +16224,7 @@
           "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.2.4.tgz",
           "integrity": "sha512-gEUlm27DewUsfUgC3T8AxkKi8Ecx+e+ZCaunB7X4Qk3i9F4C+5PSMGguolrShZ7Zb6717k79Y86f3A00O0VAZw==",
           "dev": true,
+          "optional": true,
           "requires": {
             "any-promise": "1.3.0",
             "eventemitter3": "3.1.2"
@@ -16130,6 +16235,7 @@
           "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.2.4.tgz",
           "integrity": "sha512-eZJDjyNTDtmSmzd3S488nR/SMJtNnn/GuwxnMh3AzYCqG3ZMfOylqTad2eYJPvc2PM5/Gj1wAMQcRpwOjjLuPg==",
           "dev": true,
+          "optional": true,
           "requires": {
             "underscore": "1.9.1",
             "web3-core-helpers": "1.2.4",
@@ -16143,6 +16249,7 @@
           "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.2.4.tgz",
           "integrity": "sha512-3D607J2M8ymY9V+/WZq4MLlBulwCkwEjjC2U+cXqgVO1rCyVqbxZNCmHyNYHjDDCxSEbks9Ju5xqJxDSxnyXEw==",
           "dev": true,
+          "optional": true,
           "requires": {
             "eventemitter3": "3.1.2",
             "underscore": "1.9.1",
@@ -16176,6 +16283,7 @@
           "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.2.4.tgz",
           "integrity": "sha512-8eLIY4xZKoU3DSVu1pORluAw9Ru0/v4CGdw5so31nn+7fR8zgHMgwbFe0aOqWQ5VU42PzMMXeIJwt4AEi2buFg==",
           "dev": true,
+          "optional": true,
           "requires": {
             "ethers": "4.0.0-beta.3",
             "underscore": "1.9.1",
@@ -16186,13 +16294,15 @@
               "version": "3.0.0",
               "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.0.0.tgz",
               "integrity": "sha1-4h3xCtbCBTKVvLuNq0Cwnb6ofk0=",
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "elliptic": {
               "version": "6.3.3",
               "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.3.3.tgz",
               "integrity": "sha1-VILZZG1UvLif19mU/J4ulWiHbj8=",
               "dev": true,
+              "optional": true,
               "requires": {
                 "bn.js": "^4.4.0",
                 "brorand": "^1.0.1",
@@ -16205,6 +16315,7 @@
               "resolved": "https://registry.npmjs.org/ethers/-/ethers-4.0.0-beta.3.tgz",
               "integrity": "sha512-YYPogooSknTwvHg3+Mv71gM/3Wcrx+ZpCzarBj3mqs9njjRkrOo2/eufzhHloOCo3JSoNI4TQJJ6yU5ABm3Uog==",
               "dev": true,
+              "optional": true,
               "requires": {
                 "@types/node": "^10.3.2",
                 "aes-js": "3.0.0",
@@ -16223,6 +16334,7 @@
               "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
               "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
               "dev": true,
+              "optional": true,
               "requires": {
                 "inherits": "^2.0.3",
                 "minimalistic-assert": "^1.0.0"
@@ -16232,19 +16344,22 @@
               "version": "0.5.7",
               "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
               "integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc=",
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "setimmediate": {
               "version": "1.0.4",
               "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.4.tgz",
               "integrity": "sha1-IOgd5iLUoCWIzgyNqJc8vPHTE48=",
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "uuid": {
               "version": "2.0.1",
               "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
               "integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w=",
-              "dev": true
+              "dev": true,
+              "optional": true
             }
           }
         },
@@ -16288,6 +16403,7 @@
           "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.2.4.tgz",
           "integrity": "sha512-b/9zC0qjVetEYnzRA1oZ8gF1OSSUkwSYi5LGr4GeckLkzXP7osEnp9lkO/AQcE4GpG+l+STnKPnASXJGZPgBRQ==",
           "dev": true,
+          "optional": true,
           "requires": {
             "@types/bn.js": "^4.11.4",
             "underscore": "1.9.1",
@@ -16322,6 +16438,7 @@
           "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.2.4.tgz",
           "integrity": "sha512-D9HIyctru/FLRpXakRwmwdjb5bWU2O6UE/3AXvRm6DCOf2e+7Ve11qQrPtaubHfpdW3KWjDKvlxV9iaFv/oTMQ==",
           "dev": true,
+          "optional": true,
           "requires": {
             "bn.js": "4.11.8",
             "web3-utils": "1.2.4"
@@ -16332,6 +16449,7 @@
           "resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.2.4.tgz",
           "integrity": "sha512-5Russ7ZECwHaZXcN3DLuLS7390Vzgrzepl4D87SD6Sn1DHsCZtvfdPIYwoTmKNp69LG3mORl7U23Ga5YxqkICw==",
           "dev": true,
+          "optional": true,
           "requires": {
             "@types/node": "^12.6.1",
             "web3-core": "1.2.4",
@@ -16345,7 +16463,8 @@
               "version": "12.12.14",
               "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.14.tgz",
               "integrity": "sha512-u/SJDyXwuihpwjXy7hOOghagLEV1KdAST6syfnOk6QZAMzZuWZqXy5aYYZbh8Jdpd4escVFP0MvftHNDb9pruA==",
-              "dev": true
+              "dev": true,
+              "optional": true
             }
           }
         },
@@ -16354,6 +16473,7 @@
           "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.2.4.tgz",
           "integrity": "sha512-wKOsqhyXWPSYTGbp7ofVvni17yfRptpqoUdp3SC8RAhDmGkX6irsiT9pON79m6b3HUHfLoBilFQyt/fTUZOf7A==",
           "dev": true,
+          "optional": true,
           "requires": {
             "web3-core": "1.2.4",
             "web3-core-method": "1.2.4",
@@ -16394,14 +16514,12 @@
               "integrity": "sha1-jZWCAsftuq6Dlwf7pvCf8ydgYhA=",
               "dev": true,
               "requires": {
-                "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git#1cfbb13862f90f0b391d8a699544d5fe4dfb8c7b",
                 "ethereumjs-util": "^5.1.1"
               },
               "dependencies": {
                 "ethereumjs-abi": {
                   "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#1cfbb13862f90f0b391d8a699544d5fe4dfb8c7b",
-                  "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
-                  "dev": true,
+                  "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git#1cfbb13862f90f0b391d8a699544d5fe4dfb8c7b",
                   "requires": {
                     "bn.js": "^4.11.8",
                     "ethereumjs-util": "^6.0.0"
@@ -16411,7 +16529,6 @@
                       "version": "6.2.0",
                       "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.0.tgz",
                       "integrity": "sha512-vb0XN9J2QGdZGIEKG2vXM+kUdEivUfU6Wmi5y0cg+LRhDYKnXIZ/Lz7XjFbHRR9VIKq2lVGLzGBkA++y2nOdOQ==",
-                      "dev": true,
                       "requires": {
                         "@types/bn.js": "^4.11.3",
                         "bn.js": "^4.11.0",
@@ -16428,12 +16545,18 @@
                   "version": "2.1.0",
                   "resolved": "https://registry.npmjs.org/keccak/-/keccak-2.1.0.tgz",
                   "integrity": "sha512-m1wbJRTo+gWbctZWay9i26v5fFnYkOn7D5PCxJ3fZUGUEb49dE1Pm4BREUYCt/aoO6di7jeoGmhvqN9Nzylm3Q==",
-                  "dev": true,
                   "requires": {
                     "bindings": "^1.5.0",
                     "inherits": "^2.0.4",
                     "nan": "^2.14.0",
                     "safe-buffer": "^5.2.0"
+                  },
+                  "dependencies": {
+                    "nan": {
+                      "version": "2.14.1",
+                      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
+                      "integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw=="
+                    }
                   }
                 }
               }
@@ -16591,12 +16714,6 @@
                 }
               }
             },
-            "nan": {
-              "version": "2.14.0",
-              "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
-              "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
-              "dev": true
-            },
             "ws": {
               "version": "5.2.2",
               "resolved": "https://registry.npmjs.org/ws/-/ws-5.2.2.tgz",
@@ -16613,6 +16730,7 @@
           "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.2.4.tgz",
           "integrity": "sha512-dzVCkRrR/cqlIrcrWNiPt9gyt0AZTE0J+MfAu9rR6CyIgtnm1wFUVVGaxYRxuTGQRO4Dlo49gtoGwaGcyxqiTw==",
           "dev": true,
+          "optional": true,
           "requires": {
             "web3-core-helpers": "1.2.4",
             "xhr2-cookies": "1.1.0"
@@ -16623,6 +16741,7 @@
           "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.2.4.tgz",
           "integrity": "sha512-8J3Dguffin51gckTaNrO3oMBo7g+j0UNk6hXmdmQMMNEtrYqw4ctT6t06YOf9GgtOMjSAc1YEh3LPrvgIsR7og==",
           "dev": true,
+          "optional": true,
           "requires": {
             "oboe": "2.1.4",
             "underscore": "1.9.1",
@@ -16634,6 +16753,7 @@
           "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.2.4.tgz",
           "integrity": "sha512-F/vQpDzeK+++oeeNROl1IVTufFCwCR2hpWe5yRXN0ApLwHqXrMI7UwQNdJ9iyibcWjJf/ECbauEEQ8CHgE+MYQ==",
           "dev": true,
+          "optional": true,
           "requires": {
             "@web3-js/websocket": "^1.0.29",
             "underscore": "1.9.1",
@@ -16658,6 +16778,7 @@
           "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.4.tgz",
           "integrity": "sha512-+S86Ip+jqfIPQWvw2N/xBQq5JNqCO0dyvukGdJm8fEWHZbckT4WxSpHbx+9KLEWY4H4x9pUwnoRkK87pYyHfgQ==",
           "dev": true,
+          "optional": true,
           "requires": {
             "bn.js": "4.11.8",
             "eth-lib": "0.2.7",
@@ -16674,6 +16795,7 @@
               "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
               "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
               "dev": true,
+              "optional": true,
               "requires": {
                 "bn.js": "^4.11.6",
                 "elliptic": "^6.4.0",
@@ -17079,6 +17201,7 @@
           "resolved": "https://registry.npmjs.org/xhr-request/-/xhr-request-1.1.0.tgz",
           "integrity": "sha512-Y7qzEaR3FDtL3fP30k9wO/e+FBnBByZeybKOhASsGP30NIkRAAkKD/sCnLvgEfAIEC1rcmK7YG8f4oEnIrrWzA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "buffer-to-arraybuffer": "^0.0.5",
             "object-assign": "^4.1.1",
@@ -17094,6 +17217,7 @@
           "resolved": "https://registry.npmjs.org/xhr-request-promise/-/xhr-request-promise-0.1.2.tgz",
           "integrity": "sha1-NDxE0e53JrhkgGloLQ+EDIO0Jh0=",
           "dev": true,
+          "optional": true,
           "requires": {
             "xhr-request": "^1.0.1"
           }
@@ -17103,6 +17227,7 @@
           "resolved": "https://registry.npmjs.org/xhr2-cookies/-/xhr2-cookies-1.1.0.tgz",
           "integrity": "sha1-fXdEnQmZGX8VXLc7I99yUF7YnUg=",
           "dev": true,
+          "optional": true,
           "requires": {
             "cookiejar": "^2.1.1"
           }

--- a/packages/ethereum-payments/src/BaseEthereumPayments.ts
+++ b/packages/ethereum-payments/src/BaseEthereumPayments.ts
@@ -184,7 +184,7 @@ implements BasePayments
       unconfirmedBalance: '0',
       spendableBalance: confirmedBalance,
       sweepable,
-      unactivated: false,
+      requiresActivation: false,
     }
   }
 

--- a/packages/ethereum-payments/src/BaseEthereumPayments.ts
+++ b/packages/ethereum-payments/src/BaseEthereumPayments.ts
@@ -177,11 +177,14 @@ implements BasePayments
     const payport = await this.resolvePayport(resolveablePayport)
     const balance = await this.eth.getBalance(payport.address)
     const sweepable = await this.isSweepableBalance(balance)
+    const confirmedBalance = this.toMainDenomination(balance).toString()
 
     return {
-      confirmedBalance: this.toMainDenomination(balance),
+      confirmedBalance,
       unconfirmedBalance: '0',
+      spendableBalance: confirmedBalance,
       sweepable,
+      unactivated: false,
     }
   }
 

--- a/packages/ethereum-payments/test/HdEthereumPayments.test.ts
+++ b/packages/ethereum-payments/test/HdEthereumPayments.test.ts
@@ -235,7 +235,9 @@ describe('HdEthereumPayments', () => {
         expect(res).toStrictEqual({
           confirmedBalance: '0.00000000001',
           unconfirmedBalance: '0',
+          spendableBalance: '0.00000000001',
           sweepable: true,
+          unactivated: false,
         })
       })
     })

--- a/packages/ethereum-payments/test/HdEthereumPayments.test.ts
+++ b/packages/ethereum-payments/test/HdEthereumPayments.test.ts
@@ -237,7 +237,7 @@ describe('HdEthereumPayments', () => {
           unconfirmedBalance: '0',
           spendableBalance: '0.00000000001',
           sweepable: true,
-          unactivated: false,
+          requiresActivation: false,
         })
       })
     })

--- a/packages/ethereum-payments/test/end-to-end.test.ts
+++ b/packages/ethereum-payments/test/end-to-end.test.ts
@@ -81,14 +81,14 @@ describe('end to end tests', () => {
         unconfirmedBalance: '0',
         spendableBalance: expectedBalance,
         sweepable: true,
-        unactivated: false,
+        requiresActivation: false,
       })
       expect(balanceTarget).toStrictEqual({
         confirmedBalance: '0.5',
         unconfirmedBalance: '0',
         spendableBalance: '0.5',
         sweepable: true,
-        unactivated: false,
+        requiresActivation: false,
       })
     })
 
@@ -110,14 +110,14 @@ describe('end to end tests', () => {
         unconfirmedBalance: '0',
         spendableBalance: '0',
         sweepable: false,
-        unactivated: false,
+        requiresActivation: false,
       })
       expect(balanceTarget).toStrictEqual({
         confirmedBalance: expectedSweepedBalance,
         unconfirmedBalance: '0',
         spendableBalance: expectedSweepedBalance,
         sweepable: true,
-        unactivated: false,
+        requiresActivation: false,
       })
     })
 
@@ -127,7 +127,7 @@ describe('end to end tests', () => {
         unconfirmedBalance: '0',
         spendableBalance: '0',
         sweepable: false,
-        unactivated: false,
+        requiresActivation: false,
       })
     })
   })

--- a/packages/ethereum-payments/test/end-to-end.test.ts
+++ b/packages/ethereum-payments/test/end-to-end.test.ts
@@ -79,12 +79,16 @@ describe('end to end tests', () => {
       expect(balanceSource).toStrictEqual({
         confirmedBalance: expectedBalance,
         unconfirmedBalance: '0',
-        sweepable: true
+        spendableBalance: expectedBalance,
+        sweepable: true,
+        unactivated: false,
       })
       expect(balanceTarget).toStrictEqual({
         confirmedBalance: '0.5',
         unconfirmedBalance: '0',
-        sweepable: true
+        spendableBalance: '0.5',
+        sweepable: true,
+        unactivated: false,
       })
     })
 
@@ -104,12 +108,26 @@ describe('end to end tests', () => {
       expect(balanceSource).toStrictEqual({
         confirmedBalance: '0',
         unconfirmedBalance: '0',
-        sweepable: false
+        spendableBalance: '0',
+        sweepable: false,
+        unactivated: false,
       })
       expect(balanceTarget).toStrictEqual({
         confirmedBalance: expectedSweepedBalance,
         unconfirmedBalance: '0',
-        sweepable: true
+        spendableBalance: expectedSweepedBalance,
+        sweepable: true,
+        unactivated: false,
+      })
+    })
+
+    test('can get balance of unused address', async () => {
+      expect(await hd.getBalance(12345678)).toEqual({
+        confirmedBalance: '0',
+        unconfirmedBalance: '0',
+        spendableBalance: '0',
+        sweepable: false,
+        unactivated: false,
       })
     })
   })

--- a/packages/payments-common/src/types.ts
+++ b/packages/payments-common/src/types.ts
@@ -157,7 +157,7 @@ export const BalanceResult = t.type(
     confirmedBalance: t.string, // balance with at least 1 confirmation
     unconfirmedBalance: t.string, // balance that is pending confirmation
     spendableBalance: t.string, // balance that can be spent (ie not locked in min balance)
-    unactivated: t.boolean, // true if an address doesn't have min balance
+    requiresActivation: t.boolean, // true if an address doesn't have min balance
     sweepable: t.boolean, // balance is high enough to be swept
   },
   'BalanceResult',

--- a/packages/payments-common/src/types.ts
+++ b/packages/payments-common/src/types.ts
@@ -156,6 +156,8 @@ export const BalanceResult = t.type(
   {
     confirmedBalance: t.string, // balance with at least 1 confirmation
     unconfirmedBalance: t.string, // balance that is pending confirmation
+    spendableBalance: t.string, // balance that can be spent (ie not locked in min balance)
+    unactivated: t.boolean, // true if an address doesn't have min balance
     sweepable: t.boolean, // balance is high enough to be swept
   },
   'BalanceResult',

--- a/packages/payments-common/test/types.test.ts
+++ b/packages/payments-common/test/types.test.ts
@@ -26,7 +26,7 @@ describe('types', () => {
       unconfirmedBalance: '0',
       spendableBalance: '0',
       sweepable: false,
-      unactivated: false,
+      requiresActivation: false,
     })
   })
   test('BalanceResult throws on invalid', () => {

--- a/packages/payments-common/test/types.test.ts
+++ b/packages/payments-common/test/types.test.ts
@@ -24,7 +24,9 @@ describe('types', () => {
     assertType(BalanceResult, {
       confirmedBalance: '0',
       unconfirmedBalance: '0',
+      spendableBalance: '0',
       sweepable: false,
+      unactivated: false,
     })
   })
   test('BalanceResult throws on invalid', () => {

--- a/packages/ripple-payments/package-lock.json
+++ b/packages/ripple-payments/package-lock.json
@@ -258,16 +258,6 @@
         "minimist": "^1.2.0"
       }
     },
-    "@faast/payments-common": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@faast/payments-common/-/payments-common-2.1.2.tgz",
-      "integrity": "sha512-u3IBaAzIoY4iRlpn0b9FDcVLtETBOoPIdR9kPerPE5dVYtSwBwLJ5RO2ieZUwtyw/4NtzayGulyJ2UHWBDyMrg==",
-      "requires": {
-        "@faast/ts-common": "^0.6.0",
-        "bignumber.js": "^9.0.0",
-        "io-ts": "^1.10.4"
-      }
-    },
     "@faast/ts-common": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/@faast/ts-common/-/ts-common-0.6.0.tgz",

--- a/packages/ripple-payments/src/BaseRipplePayments.ts
+++ b/packages/ripple-payments/src/BaseRipplePayments.ts
@@ -203,7 +203,7 @@ export abstract class BaseRipplePayments<Config extends BaseRipplePaymentsConfig
           unconfirmedBalance: '0',
           spendableBalance: '0',
           sweepable: false,
-          unactivated: true,
+          requiresActivation: true,
         }
       }
       throw e
@@ -218,7 +218,7 @@ export abstract class BaseRipplePayments<Config extends BaseRipplePaymentsConfig
       unconfirmedBalance: '0',
       spendableBalance: spendableBalance.toString(),
       sweepable: this.isSweepableAddressBalance(xrpAmount),
-      unactivated: confirmedBalance.lt(MIN_BALANCE),
+      requiresActivation: confirmedBalance.lt(MIN_BALANCE),
     }
   }
 
@@ -387,10 +387,10 @@ export abstract class BaseRipplePayments<Config extends BaseRipplePaymentsConfig
       options.maxLedgerVersionOffset || this.config.maxLedgerVersionOffset || DEFAULT_MAX_LEDGER_VERSION_OFFSET
     const amountString = amount.toString()
     const {
-      unactivated: fromAddressUnactivated,
+      requiresActivation: fromAddressRequiresActivation,
       confirmedBalance,
     } = await this.getBalance({ address: fromAddress })
-    if (fromAddressUnactivated) {
+    if (fromAddressRequiresActivation) {
       throw new Error(
         `Cannot send from unactivated ripple address ${fromAddress} - min balance of `
           + `${MIN_BALANCE} XRP required (${confirmedBalance} XRP)`,
@@ -414,10 +414,10 @@ export abstract class BaseRipplePayments<Config extends BaseRipplePaymentsConfig
       )
     }
     const {
-      unactivated: toAddressUnactivated,
+      requiresActivation: toAddressRequiresActivation,
       confirmedBalance: toAddressBalance,
     } = await this.getBalance({ address: toAddress })
-    if (toAddressUnactivated && amount.lt(MIN_BALANCE)) {
+    if (toAddressRequiresActivation && amount.lt(MIN_BALANCE)) {
       throw new Error(
         `Cannot send ${amountString} XRP to recipient ${toAddress} because address requires `
           + `a balance of at least ${MIN_BALANCE} XRP to receive funds (${toAddressBalance} XRP)`

--- a/packages/ripple-payments/src/BaseRipplePayments.ts
+++ b/packages/ripple-payments/src/BaseRipplePayments.ts
@@ -192,16 +192,33 @@ export abstract class BaseRipplePayments<Config extends BaseRipplePaymentsConfig
     if (!isNil(extraId)) {
       throw new Error(`Cannot getBalance of ripple payport with extraId ${extraId}, use BalanceMonitor instead`)
     }
-    const balances = await this._retryDced(() => this.api.getBalances(address))
+    let balances
+    try {
+      balances = await this._retryDced(() => this.api.getBalances(address))
+    } catch (e) {
+      if (isMatchingError(e, NOT_FOUND_ERRORS)) {
+        this.logger.debug(`Address ${address} not found`)
+        return {
+          confirmedBalance: '0',
+          unconfirmedBalance: '0',
+          spendableBalance: '0',
+          sweepable: false,
+          unactivated: true,
+        }
+      }
+      throw e
+    }
     this.logger.debug(`rippleApi.getBalance ${address}`, balances)
     const xrpBalance = balances.find(({ currency }) => currency === 'XRP')
     const xrpAmount = xrpBalance && xrpBalance.value ? xrpBalance.value : '0'
-    // Subtract locked up min balance from result to avoid confusion about what is actually spendable
-    const confirmedBalance = new BigNumber(xrpAmount).minus(MIN_BALANCE)
+    const confirmedBalance = new BigNumber(xrpAmount)
+    const spendableBalance = confirmedBalance.minus(MIN_BALANCE)
     return {
       confirmedBalance: confirmedBalance.toString(),
       unconfirmedBalance: '0',
+      spendableBalance: spendableBalance.toString(),
       sweepable: this.isSweepableAddressBalance(xrpAmount),
+      unactivated: confirmedBalance.lt(MIN_BALANCE),
     }
   }
 
@@ -332,7 +349,7 @@ export abstract class BaseRipplePayments<Config extends BaseRipplePaymentsConfig
     }
   }
 
-  private async resolvePayportBalance(
+  private async resolvePayportSpendableBalance(
     fromPayport: Payport,
     options: RippleCreateTransactionOptions,
   ): Promise<BigNumber> {
@@ -369,40 +386,41 @@ export abstract class BaseRipplePayments<Config extends BaseRipplePaymentsConfig
     const maxLedgerVersionOffset =
       options.maxLedgerVersionOffset || this.config.maxLedgerVersionOffset || DEFAULT_MAX_LEDGER_VERSION_OFFSET
     const amountString = amount.toString()
-    const fromAddressBalances = await this.getBalance({ address: fromAddress })
-    const fromAddressBalance = new BigNumber(fromAddressBalances.confirmedBalance).plus(MIN_BALANCE)
-    if (fromAddressBalance.lt(MIN_BALANCE)) {
+    const {
+      unactivated: fromAddressUnactivated,
+      confirmedBalance,
+    } = await this.getBalance({ address: fromAddress })
+    if (fromAddressUnactivated) {
       throw new Error(
-        `Cannot send from ripple address that has less than ${MIN_BALANCE} XRP: ${fromAddress} (${fromAddressBalance} XRP)`,
+        `Cannot send from unactivated ripple address ${fromAddress} - min balance of `
+          + `${MIN_BALANCE} XRP required (${confirmedBalance} XRP)`,
       )
     }
     const totalValue = amount.plus(feeMain)
-    if (fromAddressBalance.minus(totalValue).lt(MIN_BALANCE)) {
+    const balanceAfterTx = new BigNumber(confirmedBalance).minus(totalValue)
+    if (balanceAfterTx.lt(MIN_BALANCE)) {
+      const reason = balanceAfterTx.lt(0)
+        ? 'due to insufficient balance'
+        : `because it would reduce the balance below the ${MIN_BALANCE} XRP minimum`
       throw new Error(
-        `Cannot send ${amountString} XRP with fee of ${feeMain} XRP because it would reduce the balance below ` +
-          `the minimum required balance of ${MIN_BALANCE} XRP: ${fromAddress} (${fromAddressBalance} XRP)`,
+        `Cannot send ${amountString} XRP with fee of ${feeMain} XRP from ${fromAddress} `
+          + `${reason} (${confirmedBalance} XRP)`,
       )
     }
     if (typeof fromExtraId === 'string' && totalValue.gt(payportBalance)) {
       throw new Error(
         `Insufficient payport balance of ${payportBalance} XRP to send ${amountString} XRP ` +
-          `with fee of ${feeMain} XRP: ${serializePayport(fromPayport)}`,
+          `with fee of ${feeMain} XRP from ${serializePayport(fromPayport)}`,
       )
     }
-    let toAddressBalance
-    try {
-      const toAddressBalances = await this.getBalance({ address: toAddress })
-      toAddressBalance = new BigNumber(toAddressBalances.confirmedBalance).plus(MIN_BALANCE)
-    } catch (e) {
-      if (isMatchingError(e, NOT_FOUND_ERRORS)) {
-        toAddressBalance = new BigNumber(0)
-      } else {
-        throw e
-      }
-    }
-    if (toAddressBalance.lt(MIN_BALANCE) && amount.lt(MIN_BALANCE)) {
+    const {
+      unactivated: toAddressUnactivated,
+      confirmedBalance: toAddressBalance,
+    } = await this.getBalance({ address: toAddress })
+    if (toAddressUnactivated && amount.lt(MIN_BALANCE)) {
       throw new Error(
-        `Cannot send ${amountString} XRP to recipient ${toAddress} because address requires a balance of at least ${MIN_BALANCE} XRP to receive funds`
+        `Cannot send ${amountString} XRP to recipient ${toAddress} because address requires `
+          + `a balance of at least ${MIN_BALANCE} XRP to receive funds (${toAddressBalance} XRP)`
       )
     }
     const preparedTx = await this._retryDced(() =>
@@ -459,7 +477,7 @@ export abstract class BaseRipplePayments<Config extends BaseRipplePaymentsConfig
   ): Promise<RippleUnsignedTransaction> {
     const fromTo = await this.resolveFromTo(from, to)
     const feeOption = await this.resolveFeeOption(options)
-    const payportBalance = await this.resolvePayportBalance(fromTo.fromPayport, options)
+    const payportBalance = await this.resolvePayportSpendableBalance(fromTo.fromPayport, options)
     const amountBn = new BigNumber(amount)
     return this.doCreateTransaction(fromTo, feeOption, amountBn, payportBalance, options)
   }
@@ -471,12 +489,12 @@ export abstract class BaseRipplePayments<Config extends BaseRipplePaymentsConfig
   ): Promise<RippleUnsignedTransaction> {
     const fromTo = await this.resolveFromTo(from, to)
     const feeOption = await this.resolveFeeOption(options)
-    const payportBalance = await this.resolvePayportBalance(fromTo.fromPayport, options)
+    const payportBalance = await this.resolvePayportSpendableBalance(fromTo.fromPayport, options)
     let amountBn = payportBalance.minus(feeOption.feeMain)
     if (amountBn.lt(0)) {
       const fromPayport = { address: fromTo.fromAddress, extraId: fromTo.fromExtraId }
       throw new Error(
-        `Insufficient balance to sweep from ripple payport with fee of ${feeOption.feeMain} XRP: ` +
+        `Insufficient balance to sweep with fee of ${feeOption.feeMain} XRP from ripple payport ` +
           `${serializePayport(fromPayport)} (${payportBalance} XRP)`,
       )
     }

--- a/packages/ripple-payments/src/constants.ts
+++ b/packages/ripple-payments/src/constants.ts
@@ -21,7 +21,7 @@ export const EXTRA_ID_REGEX = /^[0-9]+$/
 export const XPUB_REGEX = /^xpub[a-km-zA-HJ-NP-Z1-9]{100,108}$/
 export const XPRV_REGEX = /^xprv[a-km-zA-HJ-NP-Z1-9]{100,108}$/
 
-export const NOT_FOUND_ERRORS = ['MissingLedgerHistoryError', 'NotFoundError', 'Account not found.']
+export const NOT_FOUND_ERRORS = ['MissingLedgerHistoryError', 'NotFoundError', 'Account not found.', 'actNotFound']
 
 export const DEFAULT_NETWORK = NetworkType.Mainnet
 export const DEFAULT_MAINNET_SERVER = 'wss://s1.ripple.com'

--- a/packages/ripple-payments/test/e2e.test.ts
+++ b/packages/ripple-payments/test/e2e.test.ts
@@ -109,7 +109,7 @@ describe('e2e', () => {
         unconfirmedBalance: '0',
         spendableBalance: '0',
         sweepable: false,
-        unactivated: true,
+        requiresActivation: true,
       })
     })
   })

--- a/packages/ripple-payments/test/e2e.test.ts
+++ b/packages/ripple-payments/test/e2e.test.ts
@@ -103,8 +103,14 @@ describe('e2e', () => {
       expect(balances.unconfirmedBalance).toBe('0')
       expect(balances.sweepable).toBe(true)
     })
-    it('should throw when account not activated', async () => {
-      await expect(rp.getBalance(UNACTIVATED_ADDRESS)).rejects.toThrow('Account not found.')
+    it('should return when account not activated', async () => {
+      expect(await rp.getBalance(UNACTIVATED_ADDRESS)).toEqual({
+        confirmedBalance: '0',
+        unconfirmedBalance: '0',
+        spendableBalance: '0',
+        sweepable: false,
+        unactivated: true,
+      })
     })
   })
 
@@ -300,63 +306,71 @@ describe('e2e', () => {
 
   jest.setTimeout(30 * 1000)
 
-  it.skip('should emit expected balance activities', async () => {
-    // Can't get subscriptions to work :(
-    const hotActivity = await getExpectedHotActivities()
-    const depositActivity = await getExpectedDepositActivities()
-    expect(balanceActivities).toEqual(hotActivity.concat(depositActivity))
-  })
+  describe('RippleBalanceMonitor', () => {
 
-  it('should be able to retrieve the deposit account balance activities', async () => {
-    const actual = await accumulateRetrievedActivities(rp.depositSignatory.address)
-    const expected = await getExpectedDepositActivities()
-    expectBalanceActivities(actual, expected)
-  })
+    it.skip('should emit expected balance activities', async () => {
+      // Can't get subscriptions to work :(
+      const hotActivity = await getExpectedHotActivities()
+      const depositActivity = await getExpectedDepositActivities()
+      expect(balanceActivities).toEqual(hotActivity.concat(depositActivity))
+    })
 
-  it('should be able to retrieve the hot account balance activities', async () => {
-    const actual = await accumulateRetrievedActivities(rp.hotSignatory.address)
-    const expected = await getExpectedHotActivities()
-    expectBalanceActivities(actual, expected)
-  })
+    it('should be able to retrieve the deposit account balance activities', async () => {
+      const actual = await accumulateRetrievedActivities(rp.depositSignatory.address)
+      const expected = await getExpectedDepositActivities()
+      expectBalanceActivities(actual, expected)
+    })
 
-  it('should retrieve nothing for a range without activity', async () => {
-    const sweepTx = await sweepTxPromise
-    const sendTx = await sendTxPromise
-    const from = BigNumber.max(
-      sweepTx.confirmationNumber || startLedgerVersion,
-      sendTx.confirmationNumber || startLedgerVersion,
-    ).plus(1)
-    const actual = await accumulateRetrievedActivities(rp.hotSignatory.address, { from })
-    expectBalanceActivities(actual, [])
-  })
+    it('should be able to retrieve the hot account balance activities', async () => {
+      const actual = await accumulateRetrievedActivities(rp.hotSignatory.address)
+      const expected = await getExpectedHotActivities()
+      expectBalanceActivities(actual, expected)
+    })
 
-  it.skip('should be able to retrieve more activities than page limit', async () => {
-    const actual = await accumulateRetrievedActivities('r3b5PwYSZD48G8VeXoovj3CervMRyPMyVY')
-    expect(actual.length).toBeGreaterThan(10)
-  })
+    it('should retrieve nothing for a range without activity', async () => {
+      const sweepTx = await sweepTxPromise
+      const sendTx = await sendTxPromise
+      const from = BigNumber.max(
+        sweepTx.confirmationNumber || startLedgerVersion,
+        sendTx.confirmationNumber || startLedgerVersion,
+      ).plus(1)
+      const actual = await accumulateRetrievedActivities(rp.hotSignatory.address, { from })
+      expectBalanceActivities(actual, [])
+    })
 
-  it('should recognize balance activity of txs with tec result code', async () => {
-    const [activity] = await accumulateRetrievedActivities(
-      'rJdLzYr87z7xuey8qAfh3qZ9WmaXaAoELe',
-      {
-        from: 49684653,
-        to: 49684655,
-      },
-      bmMainnet,
-    )
-    expect(activity).toEqual({
-      type: 'out',
-      networkType: 'mainnet',
-      networkSymbol: 'XRP',
-      assetSymbol: 'XRP',
-      address: 'rJdLzYr87z7xuey8qAfh3qZ9WmaXaAoELe',
-      extraId: '12',
-      amount: '-0.000012',
-      externalId: 'F5C7793E506E9566CED0060D9FC519BA06BD0EB0F4A77C0680BEA8FD13A13A58',
-      activitySequence: '000049684654.00000040.00',
-      confirmationId: '4103BE72C0C718AD2B137C9B40C37AD3D157044A61F40AB74B122A12EFB15B32',
-      confirmationNumber: '49684654',
-      timestamp: new Date('2019-08-30T01:11:52.000Z'),
+    it.skip('should be able to retrieve more activities than page limit', async () => {
+      const actual = await accumulateRetrievedActivities('r3b5PwYSZD48G8VeXoovj3CervMRyPMyVY')
+      expect(actual.length).toBeGreaterThan(10)
+    })
+
+    it('should recognize balance activity of txs with tec result code', async () => {
+      const [activity] = await accumulateRetrievedActivities(
+        'rJdLzYr87z7xuey8qAfh3qZ9WmaXaAoELe',
+        {
+          from: 49684653,
+          to: 49684655,
+        },
+        bmMainnet,
+      )
+      expect(activity).toEqual({
+        type: 'out',
+        networkType: 'mainnet',
+        networkSymbol: 'XRP',
+        assetSymbol: 'XRP',
+        address: 'rJdLzYr87z7xuey8qAfh3qZ9WmaXaAoELe',
+        extraId: '12',
+        amount: '-0.000012',
+        externalId: 'F5C7793E506E9566CED0060D9FC519BA06BD0EB0F4A77C0680BEA8FD13A13A58',
+        activitySequence: '000049684654.00000040.00',
+        confirmationId: '4103BE72C0C718AD2B137C9B40C37AD3D157044A61F40AB74B122A12EFB15B32',
+        confirmationNumber: '49684654',
+        timestamp: new Date('2019-08-30T01:11:52.000Z'),
+      })
+    })
+
+    it('should not throw for unactivated address', async () => {
+      const activities = await accumulateRetrievedActivities(UNACTIVATED_ADDRESS)
+      expect(activities).toEqual([])
     })
   })
 

--- a/packages/stellar-payments/package-lock.json
+++ b/packages/stellar-payments/package-lock.json
@@ -258,16 +258,6 @@
         "minimist": "^1.2.0"
       }
     },
-    "@faast/payments-common": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@faast/payments-common/-/payments-common-2.1.2.tgz",
-      "integrity": "sha512-u3IBaAzIoY4iRlpn0b9FDcVLtETBOoPIdR9kPerPE5dVYtSwBwLJ5RO2ieZUwtyw/4NtzayGulyJ2UHWBDyMrg==",
-      "requires": {
-        "@faast/ts-common": "^0.6.0",
-        "bignumber.js": "^9.0.0",
-        "io-ts": "^1.10.4"
-      }
-    },
     "@faast/ts-common": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/@faast/ts-common/-/ts-common-0.6.0.tgz",

--- a/packages/stellar-payments/src/BaseStellarPayments.ts
+++ b/packages/stellar-payments/src/BaseStellarPayments.ts
@@ -180,7 +180,7 @@ export abstract class BaseStellarPayments<Config extends BaseStellarPaymentsConf
         unconfirmedBalance: '0',
         spendableBalance: '0',
         sweepable: false,
-        unactivated: true,
+        requiresActivation: true,
       }
     }
     const balanceLine = accountInfo.balances.find((line) => line.asset_type === 'native')
@@ -192,7 +192,7 @@ export abstract class BaseStellarPayments<Config extends BaseStellarPaymentsConf
       unconfirmedBalance: '0',
       spendableBalance: spendableBalance.toString(),
       sweepable: this.isSweepableAddressBalance(amountMain),
-      unactivated: false,
+      requiresActivation: false,
     }
   }
 
@@ -385,10 +385,10 @@ export abstract class BaseStellarPayments<Config extends BaseStellarPaymentsConf
     const txTimeoutSecs = options.timeoutSeconds || this.config.txTimeoutSeconds || DEFAULT_TX_TIMEOUT_SECONDS
     const amountString = amount.toString()
     const {
-      unactivated: fromAddressUnactivated,
+      requiresActivation: fromAddressRequiresActivation,
       confirmedBalance: fromAddressBalance,
     } = await this.getBalance({ address: fromAddress })
-    if (fromAddressUnactivated) {
+    if (fromAddressRequiresActivation) {
       throw new Error(
         `Cannot send from unactivated stellar address ${fromAddress} - min balance of `
           + `${MIN_BALANCE} XLM required (${fromAddressBalance} XLM)`,
@@ -412,10 +412,10 @@ export abstract class BaseStellarPayments<Config extends BaseStellarPaymentsConf
       )
     }
     const {
-      unactivated: toAddressUnactivated,
+      requiresActivation: toAddressRequiresActivation,
       confirmedBalance: toAddressBalance,
     } = await this.getBalance({ address: toAddress })
-    if (toAddressUnactivated && amount.lt(MIN_BALANCE)) {
+    if (toAddressRequiresActivation && amount.lt(MIN_BALANCE)) {
       throw new Error(
         `Cannot send ${amountString} XLM to recipient ${toAddress} because address requires `
           + `a balance of at least ${MIN_BALANCE} XLM to receive funds (${toAddressBalance} XLM)`

--- a/packages/stellar-payments/src/BaseStellarPayments.ts
+++ b/packages/stellar-payments/src/BaseStellarPayments.ts
@@ -150,7 +150,7 @@ export abstract class BaseStellarPayments<Config extends BaseStellarPaymentsConf
       accountInfo = await this._retryDced(() => this.getApi().loadAccount(address))
     } catch (e) {
       if (isMatchingError(e, NOT_FOUND_ERRORS)) {
-        this.logger.debug('api.loadAccount account not found', address)
+        this.logger.debug(`Address ${address} not found`)
         return null
       }
       throw e
@@ -173,16 +173,26 @@ export abstract class BaseStellarPayments<Config extends BaseStellarPaymentsConf
     if (!isNil(extraId)) {
       throw new Error(`Cannot getBalance of stellar payport with extraId ${extraId}, use BalanceMonitor instead`)
     }
-    const accountInfo = await this.loadAccountOrThrow(address)
+    const accountInfo = await this.loadAccount(address)
+    if (accountInfo === null) {
+      return {
+        confirmedBalance: '0',
+        unconfirmedBalance: '0',
+        spendableBalance: '0',
+        sweepable: false,
+        unactivated: true,
+      }
+    }
     const balanceLine = accountInfo.balances.find((line) => line.asset_type === 'native')
     const amountMain = new BigNumber(balanceLine && balanceLine.balance ? balanceLine.balance : '0')
-    // Subtract locked up min balance from result to avoid confusion about what is actually spendable
-    const confirmedBalance = amountMain.minus(MIN_BALANCE)
-    this.logger.debug(`getBalance ${address}/${extraId}`, confirmedBalance)
+    this.logger.debug(`getBalance ${address}/${extraId}`, amountMain)
+    const spendableBalance = amountMain.minus(MIN_BALANCE)
     return {
-      confirmedBalance: confirmedBalance.toString(),
+      confirmedBalance: amountMain.toString(),
       unconfirmedBalance: '0',
+      spendableBalance: spendableBalance.toString(),
       sweepable: this.isSweepableAddressBalance(amountMain),
+      unactivated: false,
     }
   }
 
@@ -374,25 +384,41 @@ export abstract class BaseStellarPayments<Config extends BaseStellarPaymentsConf
     const sequenceNumber = toBigNumber(seqNo)
     const txTimeoutSecs = options.timeoutSeconds || this.config.txTimeoutSeconds || DEFAULT_TX_TIMEOUT_SECONDS
     const amountString = amount.toString()
-    const addressBalances = await this.getBalance({ address: fromAddress })
-    const addressBalance = new BigNumber(addressBalances.confirmedBalance)
-    const actualBalance = addressBalance.plus(MIN_BALANCE)
-    if (addressBalance.lt(0)) {
+    const {
+      unactivated: fromAddressUnactivated,
+      confirmedBalance: fromAddressBalance,
+    } = await this.getBalance({ address: fromAddress })
+    if (fromAddressUnactivated) {
       throw new Error(
-        `Cannot send from stellar address that has less than ${MIN_BALANCE} XLM: ${fromAddress} (${actualBalance} XLM)`,
+        `Cannot send from unactivated stellar address ${fromAddress} - min balance of `
+          + `${MIN_BALANCE} XLM required (${fromAddressBalance} XLM)`,
       )
     }
     const totalValue = amount.plus(feeMain)
-    if (addressBalance.minus(totalValue).lt(0)) {
+    const balanceAfterTx = new BigNumber(fromAddressBalance).minus(totalValue)
+    if (balanceAfterTx.lt(MIN_BALANCE)) {
+      const reason = balanceAfterTx.lt(0)
+        ? 'due to insufficient balance'
+        : `because it would reduce the balance below the ${MIN_BALANCE} XLM minimum`
       throw new Error(
-        `Cannot send ${amountString} XLM with fee of ${feeMain} XLM because it would reduce the balance below ` +
-          `the minimum required balance of ${MIN_BALANCE} XLM: ${fromAddress} (${actualBalance} XLM)`,
+        `Cannot send ${amountString} XLM with fee of ${feeMain} XLM from ${fromAddress} `
+          + `${reason} (${fromAddressBalance} XLM)`,
       )
     }
     if (typeof fromExtraId === 'string' && totalValue.gt(payportBalance)) {
       throw new Error(
         `Insufficient payport balance of ${payportBalance} XLM to send ${amountString} XLM ` +
-          `with fee of ${feeMain} XLM: ${serializePayport(fromPayport)}`,
+          `with fee of ${feeMain} XLM from ${serializePayport(fromPayport)}`,
+      )
+    }
+    const {
+      unactivated: toAddressUnactivated,
+      confirmedBalance: toAddressBalance,
+    } = await this.getBalance({ address: toAddress })
+    if (toAddressUnactivated && amount.lt(MIN_BALANCE)) {
+      throw new Error(
+        `Cannot send ${amountString} XLM to recipient ${toAddress} because address requires `
+          + `a balance of at least ${MIN_BALANCE} XLM to receive funds (${toAddressBalance} XLM)`
       )
     }
     const fromAccount = await this.loadAccountOrThrow(fromAddress)

--- a/packages/stellar-payments/test/e2e.test.ts
+++ b/packages/stellar-payments/test/e2e.test.ts
@@ -111,7 +111,7 @@ describe('e2e', () => {
         unconfirmedBalance: '0',
         spendableBalance: '0',
         sweepable: false,
-        unactivated: true,
+        requiresActivation: true,
       })
     })
   })

--- a/packages/stellar-payments/test/e2e.test.ts
+++ b/packages/stellar-payments/test/e2e.test.ts
@@ -2,6 +2,7 @@ import { TransactionStatus, BalanceActivity, NetworkType, GetBalanceActivityOpti
 import BigNumber from 'bignumber.js'
 import { sortBy } from 'lodash'
 import StellarHD from 'stellar-hd-wallet'
+import crypto from 'crypto'
 
 import {
   isValidAddress, StellarSignedTransaction, AccountStellarPayments,
@@ -21,6 +22,7 @@ jest.setTimeout(60 * 1000)
 
 const FRESH_INDEX = Math.floor(Date.now() / 1000) - 1573074564
 const FRESH_ADDRESS = StellarHD.fromSeed('1234').getPublicKey(FRESH_INDEX)
+const UNACTIVATED_ADDRESS = StellarHD.fromSeed(crypto.randomBytes(8)).getPublicKey(0)
 
 describe('e2e', () => {
   let testsComplete: boolean = false
@@ -102,6 +104,15 @@ describe('e2e', () => {
       expect(Number.parseInt(balances.confirmedBalance)).toBeGreaterThan(0)
       expect(balances.unconfirmedBalance).toBe('0')
       expect(balances.sweepable).toBe(true)
+    })
+    it('should return when account not activated', async () => {
+      expect(await payments.getBalance(UNACTIVATED_ADDRESS)).toEqual({
+        confirmedBalance: '0',
+        unconfirmedBalance: '0',
+        spendableBalance: '0',
+        sweepable: false,
+        unactivated: true,
+      })
     })
   })
 
@@ -328,40 +339,47 @@ describe('e2e', () => {
 
   jest.setTimeout(30 * 1000)
 
-  it('should emit expected balance activities', async () => {
-    const hotActivity = await getExpectedHotActivities()
-    const depositActivity = await getExpectedDepositActivities()
-    expectBalanceActivities(emittedBalanceActivities, hotActivity.concat(depositActivity))
-  })
+  describe('StellarBalanceMonitor', () => {
+    it('should emit expected balance activities', async () => {
+      const hotActivity = await getExpectedHotActivities()
+      const depositActivity = await getExpectedDepositActivities()
+      expectBalanceActivities(emittedBalanceActivities, hotActivity.concat(depositActivity))
+    })
 
-  it('should be able to retrieve the deposit account balance activities', async () => {
-    const actual = await accumulateRetrievedActivities(payments.depositSignatory.address)
-    const expected = await getExpectedDepositActivities()
-    expectBalanceActivities(actual, expected)
-  })
+    it('should be able to retrieve the deposit account balance activities', async () => {
+      const actual = await accumulateRetrievedActivities(payments.depositSignatory.address)
+      const expected = await getExpectedDepositActivities()
+      expectBalanceActivities(actual, expected)
+    })
 
-  it('should be able to retrieve the hot account balance activities', async () => {
-    const actual = await accumulateRetrievedActivities(payments.hotSignatory.address)
-    const expected = await getExpectedHotActivities()
-    expectBalanceActivities(actual, expected)
-  })
+    it('should be able to retrieve the hot account balance activities', async () => {
+      const actual = await accumulateRetrievedActivities(payments.hotSignatory.address)
+      const expected = await getExpectedHotActivities()
+      expectBalanceActivities(actual, expected)
+    })
 
-  it('should retrieve nothing for a range without activity', async () => {
-    const txs = [
-      await sweepTxPromise, await sendTxPromise, await sendFreshTxPromise
-    ]
-    const from = BigNumber.max(...txs.map((tx) => tx.confirmationNumber || startLedgerVersion))
-      .plus(1)
-    const actual = await accumulateRetrievedActivities(payments.hotSignatory.address, { from })
-    expectBalanceActivities(actual, [])
-  })
+    it('should retrieve nothing for a range without activity', async () => {
+      const txs = [
+        await sweepTxPromise, await sendTxPromise, await sendFreshTxPromise
+      ]
+      const from = BigNumber.max(...txs.map((tx) => tx.confirmationNumber || startLedgerVersion))
+        .plus(1)
+      const actual = await accumulateRetrievedActivities(payments.hotSignatory.address, { from })
+      expectBalanceActivities(actual, [])
+    })
 
-  it('should be able to retrieve more activities than page limit', async () => {
-    const actual = await accumulateRetrievedActivities('GDHMECSDSY3U66WAZMO3RFJXTNCGCFFVHINONHTWU2VPHHRFSBKHWMOL', {
-      from: 24895758,
-      to: 26463647,
-    }, monitorMainnet)
-    expect(actual.length).toBeGreaterThan(10)
+    it('should be able to retrieve more activities than page limit', async () => {
+      const actual = await accumulateRetrievedActivities('GDHMECSDSY3U66WAZMO3RFJXTNCGCFFVHINONHTWU2VPHHRFSBKHWMOL', {
+        from: 24895758,
+        to: 26463647,
+      }, monitorMainnet)
+      expect(actual.length).toBeGreaterThan(10)
+    })
+
+    it('should not throw for unactivated address', async () => {
+      const activities = await accumulateRetrievedActivities(UNACTIVATED_ADDRESS)
+      expect(activities).toEqual([])
+    })
   })
 
   it('should create tx correctly when sequenceNumber option provided', async () => {

--- a/packages/tron-payments/package-lock.json
+++ b/packages/tron-payments/package-lock.json
@@ -286,16 +286,6 @@
         }
       }
     },
-    "@faast/payments-common": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@faast/payments-common/-/payments-common-2.1.2.tgz",
-      "integrity": "sha512-u3IBaAzIoY4iRlpn0b9FDcVLtETBOoPIdR9kPerPE5dVYtSwBwLJ5RO2ieZUwtyw/4NtzayGulyJ2UHWBDyMrg==",
-      "requires": {
-        "@faast/ts-common": "^0.6.0",
-        "bignumber.js": "^9.0.0",
-        "io-ts": "^1.10.4"
-      }
-    },
     "@faast/ts-common": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/@faast/ts-common/-/ts-common-0.6.0.tgz",

--- a/packages/tron-payments/src/BaseTronPayments.ts
+++ b/packages/tron-payments/src/BaseTronPayments.ts
@@ -89,7 +89,7 @@ export abstract class BaseTronPayments<Config extends BaseTronPaymentsConfig> ex
         unconfirmedBalance: '0',
         spendableBalance: spendableBalance.toString(),
         sweepable,
-        unactivated: false,
+        requiresActivation: false,
       }
     } catch (e) {
       throw toError(e)

--- a/packages/tron-payments/src/BaseTronPayments.ts
+++ b/packages/tron-payments/src/BaseTronPayments.ts
@@ -26,7 +26,7 @@ import {
   BaseTronPaymentsConfig,
   TronWebTransaction,
 } from './types'
-import { toBaseDenominationNumber, isValidAddress } from './helpers'
+import { toBaseDenominationNumber, isValidAddress, toMainDenominationBigNumber } from './helpers'
 import { toError } from './utils'
 import {
   DEFAULT_FULL_NODE,
@@ -39,6 +39,7 @@ import {
   TX_EXPIRATION_EXTENSION_SECONDS,
 } from './constants'
 import { TronPaymentsUtils } from './TronPaymentsUtils'
+import BigNumber from 'bignumber.js';
 
 export abstract class BaseTronPayments<Config extends BaseTronPaymentsConfig> extends TronPaymentsUtils
   implements
@@ -81,10 +82,14 @@ export abstract class BaseTronPayments<Config extends BaseTronPaymentsConfig> ex
       const balanceSun = await this.tronweb.trx.getBalance(payport.address)
       this.logger.debug(`trx.getBalance(${payport.address}) -> ${balanceSun}`)
       const sweepable = this.canSweepBalance(balanceSun)
+      const confirmedBalance = toMainDenominationBigNumber(balanceSun)
+      const spendableBalance = BigNumber.max(0, confirmedBalance.minus(MIN_BALANCE_TRX))
       return {
-        confirmedBalance: this.toMainDenomination(balanceSun).toString(),
+        confirmedBalance: confirmedBalance.toString(),
         unconfirmedBalance: '0',
+        spendableBalance: spendableBalance.toString(),
         sweepable,
+        unactivated: false,
       }
     } catch (e) {
       throw toError(e)

--- a/packages/tron-payments/src/constants.ts
+++ b/packages/tron-payments/src/constants.ts
@@ -1,9 +1,12 @@
 import { FeeLevel } from '@faast/payments-common'
 
 export const PACKAGE_NAME = 'tron-payments'
-export const MIN_BALANCE_SUN = 100000
-export const MIN_BALANCE_TRX = MIN_BALANCE_SUN / 1e6
 export const DECIMAL_PLACES = 6
+
+// Note: Tron doesn't actually have a minimum balance, but 0.1 trx could be burned when sending to
+// a new address so we need to keep at least this much around to cover those cases.
+export const MIN_BALANCE_SUN = 100000
+export const MIN_BALANCE_TRX = 0.1
 
 export const DEFAULT_FULL_NODE = process.env.TRX_FULL_NODE_URL || 'https://api.trongrid.io'
 export const DEFAULT_SOLIDITY_NODE = process.env.TRX_SOLIDITY_NODE_URL || 'https://api.trongrid.io'

--- a/packages/tron-payments/test/HdTronPayments.test.ts
+++ b/packages/tron-payments/test/HdTronPayments.test.ts
@@ -146,7 +146,7 @@ function runHardcodedPublicKeyTests(tp: HdTronPayments, config: HdTronPaymentsCo
       unconfirmedBalance: '0',
       spendableBalance: '0',
       sweepable: false,
-      unactivated: false,
+      requiresActivation: false,
     })
   })
   it('get a balance using an address', async () => {
@@ -155,7 +155,7 @@ function runHardcodedPublicKeyTests(tp: HdTronPayments, config: HdTronPaymentsCo
       unconfirmedBalance: '0',
       spendableBalance: '0',
       sweepable: false,
-      unactivated: false,
+      requiresActivation: false,
     })
   })
   it('should not throw for unused address', async () => {
@@ -164,7 +164,7 @@ function runHardcodedPublicKeyTests(tp: HdTronPayments, config: HdTronPaymentsCo
       unconfirmedBalance: '0',
       spendableBalance: '0',
       sweepable: false,
-      unactivated: false,
+      requiresActivation: false,
     })
   })
 
@@ -255,7 +255,7 @@ describe('HdTronPayments', () => {
           unconfirmedBalance: '0',
           spendableBalance: '2.1',
           sweepable: true,
-          unactivated: false,
+          requiresActivation: false,
         })
       })
       it('get correct balance for address 0', async () => {
@@ -264,7 +264,7 @@ describe('HdTronPayments', () => {
           unconfirmedBalance: '0',
           spendableBalance: '2.1',
           sweepable: true,
-          unactivated: false,
+          requiresActivation: false,
         })
       })
 

--- a/packages/tron-payments/test/HdTronPayments.test.ts
+++ b/packages/tron-payments/test/HdTronPayments.test.ts
@@ -144,16 +144,30 @@ function runHardcodedPublicKeyTests(tp: HdTronPayments, config: HdTronPaymentsCo
     expect(await tp.getBalance(1)).toEqual({
       confirmedBalance: '0',
       unconfirmedBalance: '0',
+      spendableBalance: '0',
       sweepable: false,
+      unactivated: false,
     })
   })
   it('get a balance using an address', async () => {
     expect(await tp.getBalance({ address: 'TBR4KDPrN9BrnyjienckS2xixcTpJ9aP26' })).toEqual({
       confirmedBalance: '0',
       unconfirmedBalance: '0',
+      spendableBalance: '0',
       sweepable: false,
+      unactivated: false,
     })
   })
+  it('should not throw for unused address', async () => {
+    expect(await tp.getBalance(12345678)).toEqual({
+      confirmedBalance: '0',
+      unconfirmedBalance: '0',
+      spendableBalance: '0',
+      sweepable: false,
+      unactivated: false,
+    })
+  })
+
   it('broadcast an existing sweep transaction', async () => {
     const result = await tp.broadcastTransaction(signedTx_valid)
     expect(result).toEqual({
@@ -239,14 +253,18 @@ describe('HdTronPayments', () => {
         expect(await tp.getBalance(0)).toEqual({
           confirmedBalance: '2.2',
           unconfirmedBalance: '0',
+          spendableBalance: '2.1',
           sweepable: true,
+          unactivated: false,
         })
       })
       it('get correct balance for address 0', async () => {
         expect(await tp.getBalance({ address: address0 })).toEqual({
           confirmedBalance: '2.2',
           unconfirmedBalance: '0',
+          spendableBalance: '2.1',
           sweepable: true,
+          unactivated: false,
         })
       })
 


### PR DESCRIPTION
Currently calling `getBalance` on an unused address will either return a zero balance (BTC, ETH, TRX) or throw an error (XRP, XLM). This PR makes all coins return zero balances when an address is unused.

Summary of changes to `getBalance` result:
- Adjust `confirmedBalance` to no longer deduct the minimum balance and better reflect what it's name implies
- Add `spendableBalance` to convey how much can actually be spent. (ie `confirmedBalance + unconfirmedBalance - minBalance`)
- Add `unactivated` flag to indicate that an address has not yet received the minimum balance needed to be activated (XRP and XLM)