### PR TITLE
[fix] (common) prohibit fractual base denomination

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3870,8 +3870,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3892,14 +3891,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3914,20 +3911,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4044,8 +4038,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4057,7 +4050,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4072,7 +4064,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4080,14 +4071,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -4106,7 +4095,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4187,8 +4175,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4200,7 +4187,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4286,8 +4272,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4323,7 +4308,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4343,7 +4327,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4387,14 +4370,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },

--- a/packages/ethereum-payments/package-lock.json
+++ b/packages/ethereum-payments/package-lock.json
@@ -241,6 +241,16 @@
         "minimist": "^1.2.0"
       }
     },
+    "@faast/payments-common": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@faast/payments-common/-/payments-common-2.4.0.tgz",
+      "integrity": "sha512-YZN9/DSZ9uFjoRUvk/CT7CFGOlspPAXTFolN/ll32jCFPbumK/bTR4NWJPsoXlboWMBTL9hTS/5pFAe8ha+tFw==",
+      "requires": {
+        "@faast/ts-common": "^0.6.0",
+        "bignumber.js": "^9.0.0",
+        "io-ts": "^1.10.4"
+      }
+    },
     "@faast/ts-common": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/@faast/ts-common/-/ts-common-0.6.0.tgz",
@@ -3122,8 +3132,7 @@
           "version": "2.1.1",
           "resolved": false,
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3147,15 +3156,13 @@
           "version": "1.0.0",
           "resolved": false,
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "resolved": false,
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3172,22 +3179,19 @@
           "version": "1.1.0",
           "resolved": false,
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "resolved": false,
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "resolved": false,
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3318,8 +3322,7 @@
           "version": "2.0.4",
           "resolved": false,
           "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3333,7 +3336,6 @@
           "resolved": false,
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3350,7 +3352,6 @@
           "resolved": false,
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3359,15 +3360,13 @@
           "version": "0.0.8",
           "resolved": false,
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.9.0",
           "resolved": false,
           "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -3388,7 +3387,6 @@
           "resolved": false,
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3487,8 +3485,7 @@
           "version": "1.0.1",
           "resolved": false,
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3502,7 +3499,6 @@
           "resolved": false,
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3598,8 +3594,7 @@
           "version": "5.1.2",
           "resolved": false,
           "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3641,7 +3636,6 @@
           "resolved": false,
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3663,7 +3657,6 @@
           "resolved": false,
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3712,15 +3705,13 @@
           "version": "1.0.2",
           "resolved": false,
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.1.1",
           "resolved": false,
           "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -3985,7 +3976,6 @@
           "resolved": "https://registry.npmjs.org/@types/bignumber.js/-/bignumber.js-5.0.0.tgz",
           "integrity": "sha512-0DH7aPGCClywOFaxxjE6UwpN2kQYe9LwuDQMv+zYA97j5GkOMo8e66LYT+a8JYU7jfmUFRZLa9KycxHDsKXJCA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "bignumber.js": "*"
           }
@@ -4049,7 +4039,6 @@
           "resolved": "https://registry.npmjs.org/@web3-js/websocket/-/websocket-1.0.30.tgz",
           "integrity": "sha512-fDwrD47MiDrzcJdSeTLF75aCcxVVt8B1N74rA+vh2XCAvFy4tEWJjtnUtj2QG7/zlQ6g9cQ88bZFBxwd9/FmtA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "debug": "^2.2.0",
             "es5-ext": "^0.10.50",
@@ -4063,7 +4052,6 @@
               "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
               "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
               "dev": true,
-              "optional": true,
               "requires": {
                 "ms": "2.0.0"
               }
@@ -4072,15 +4060,13 @@
               "version": "2.0.0",
               "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
               "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "nan": {
               "version": "2.14.0",
               "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
               "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
-              "dev": true,
-              "optional": true
+              "dev": true
             }
           }
         },
@@ -4382,8 +4368,7 @@
           "version": "1.3.0",
           "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
           "integrity": "sha1-q8av7tzqUugJzcA3au0845Y10X8=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "anymatch": {
           "version": "2.0.0",
@@ -5493,8 +5478,7 @@
           "version": "9.0.0",
           "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.0.tgz",
           "integrity": "sha512-t/OYhhJ2SD+YGBQcjY8GzzDHEk9f3nerxjtfa6tlMXfe7frs/WozhvCNoGvpM0P3bNf3Gq5ZRMlGr5f3r4/N8A==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "binary-extensions": {
           "version": "1.13.1",
@@ -5535,7 +5519,6 @@
           "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
           "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "readable-stream": "^2.3.5",
             "safe-buffer": "^5.1.1"
@@ -5556,7 +5539,6 @@
           "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.0.tgz",
           "integrity": "sha512-dhEPs72UPbDnAQJ9ZKMNTP6ptJaionhP5cBb541nXPlW60Jepo9RV/a4fX4XWW9CuFNK22krhrj1+rgzifNCsw==",
           "dev": true,
-          "optional": true,
           "requires": {
             "bytes": "3.1.0",
             "content-type": "~1.0.4",
@@ -5575,7 +5557,6 @@
               "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
               "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
               "dev": true,
-              "optional": true,
               "requires": {
                 "ms": "2.0.0"
               }
@@ -5584,8 +5565,7 @@
               "version": "2.0.0",
               "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
               "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-              "dev": true,
-              "optional": true
+              "dev": true
             }
           }
         },
@@ -5766,7 +5746,6 @@
           "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
           "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
           "dev": true,
-          "optional": true,
           "requires": {
             "buffer-alloc-unsafe": "^1.1.0",
             "buffer-fill": "^1.0.0"
@@ -5776,8 +5755,7 @@
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
           "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "buffer-crc32": {
           "version": "0.2.13",
@@ -5796,8 +5774,7 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
           "integrity": "sha1-+PeLdniYiO858gXNY39o5wISKyw=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "buffer-from": {
           "version": "1.1.1",
@@ -5808,8 +5785,7 @@
           "version": "0.0.5",
           "resolved": "https://registry.npmjs.org/buffer-to-arraybuffer/-/buffer-to-arraybuffer-0.0.5.tgz",
           "integrity": "sha1-YGSkD6dutDxyOrqe+PbhIW0QURo=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "buffer-xor": {
           "version": "1.0.3",
@@ -5825,8 +5801,7 @@
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
           "integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "bytewise": {
           "version": "1.1.0",
@@ -6363,8 +6338,7 @@
           "version": "1.0.4",
           "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
           "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "convert-source-map": {
           "version": "1.6.0",
@@ -6399,8 +6373,7 @@
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.2.tgz",
           "integrity": "sha512-Mw+adcfzPxcPeI+0WlvRrr/3lGVO0bD75SxX6811cxSh1Wbxx7xZBGK1eVtDf6si8rg2lhnUjsVLMFMfbRIuwA==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "copy-concurrently": {
           "version": "1.0.5",
@@ -6692,7 +6665,6 @@
           "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
           "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
           "dev": true,
-          "optional": true,
           "requires": {
             "mimic-response": "^1.0.0"
           }
@@ -6702,7 +6674,6 @@
           "resolved": "https://registry.npmjs.org/decompress-tar/-/decompress-tar-4.1.1.tgz",
           "integrity": "sha512-JdJMaCrGpB5fESVyxwpCx4Jdj2AagLmv3y58Qy4GE6HMVjWz1FeVQk1Ct4Kye7PftcdOo/7U7UKzYBJgqnGeUQ==",
           "dev": true,
-          "optional": true,
           "requires": {
             "file-type": "^5.2.0",
             "is-stream": "^1.1.0",
@@ -6954,8 +6925,7 @@
           "version": "1.1.2",
           "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
           "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "des.js": {
           "version": "1.0.0",
@@ -6970,8 +6940,7 @@
           "version": "1.0.4",
           "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
           "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "detect-file": {
           "version": "1.0.0",
@@ -7036,8 +7005,7 @@
           "version": "0.1.4",
           "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
           "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "duplexify": {
           "version": "3.7.1",
@@ -7073,8 +7041,7 @@
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
           "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "electron-to-chromium": {
           "version": "1.3.237",
@@ -7115,8 +7082,7 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
           "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "encoding": {
           "version": "0.1.12",
@@ -7270,8 +7236,7 @@
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
           "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "escape-string-regexp": {
           "version": "1.0.5",
@@ -7631,8 +7596,7 @@
           "version": "1.8.1",
           "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
           "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "eth-block-tracker": {
           "version": "3.0.1",
@@ -8135,7 +8099,6 @@
           "resolved": "https://registry.npmjs.org/ethereum-bloom-filters/-/ethereum-bloom-filters-1.0.6.tgz",
           "integrity": "sha512-dE9CGNzgOOsdh7msZirvv8qjHtnHpvBlKe2647kM8v+yeF71IRso55jpojemvHV+jMjr48irPWxMRaHuOWzAFA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "js-sha3": "^0.8.0"
           },
@@ -8144,8 +8107,7 @@
               "version": "0.8.0",
               "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
               "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==",
-              "dev": true,
-              "optional": true
+              "dev": true
             }
           }
         },
@@ -8376,7 +8338,6 @@
           "resolved": "https://registry.npmjs.org/ethjs-unit/-/ethjs-unit-0.1.6.tgz",
           "integrity": "sha1-xmWSHkduh7ziqdWIpv4EBbLEFpk=",
           "dev": true,
-          "optional": true,
           "requires": {
             "bn.js": "4.11.6",
             "number-to-bn": "1.7.0"
@@ -8386,8 +8347,7 @@
               "version": "4.11.6",
               "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
               "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU=",
-              "dev": true,
-              "optional": true
+              "dev": true
             }
           }
         },
@@ -8404,8 +8364,7 @@
           "version": "3.1.2",
           "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
           "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "events": {
           "version": "3.0.0",
@@ -8755,8 +8714,7 @@
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/file-type/-/file-type-5.2.0.tgz",
           "integrity": "sha1-LdvqfHP/42No365J3DOMBYwritY=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "file-uri-to-path": {
           "version": "1.0.0",
@@ -9064,8 +9022,7 @@
           "version": "0.5.2",
           "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
           "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "from2": {
           "version": "2.3.0",
@@ -9080,8 +9037,7 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
           "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "fs-extra": {
           "version": "4.0.3",
@@ -9148,8 +9104,7 @@
             },
             "ansi-regex": {
               "version": "2.1.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -9167,13 +9122,11 @@
             },
             "balanced-match": {
               "version": "1.0.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -9186,18 +9139,15 @@
             },
             "code-point-at": {
               "version": "1.1.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "concat-map": {
               "version": "0.0.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -9300,8 +9250,7 @@
             },
             "inherits": {
               "version": "2.0.3",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "ini": {
               "version": "1.3.5",
@@ -9311,7 +9260,6 @@
             "is-fullwidth-code-point": {
               "version": "1.0.0",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -9324,20 +9272,17 @@
             "minimatch": {
               "version": "3.0.4",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
             },
             "minimist": {
               "version": "0.0.8",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -9354,7 +9299,6 @@
             "mkdirp": {
               "version": "0.5.1",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -9427,8 +9371,7 @@
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -9438,7 +9381,6 @@
             "once": {
               "version": "1.4.0",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -9514,8 +9456,7 @@
             },
             "safe-buffer": {
               "version": "5.1.2",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -9545,7 +9486,6 @@
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -9563,7 +9503,6 @@
             "strip-ansi": {
               "version": "3.0.1",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -9602,13 +9541,11 @@
             },
             "wrappy": {
               "version": "1.0.2",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "yallist": {
               "version": "3.0.3",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             }
           }
         },
@@ -10086,7 +10023,6 @@
           "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.2.tgz",
           "integrity": "sha512-uUQBt3H/cSIVfch6i1EuPNy/YsRSOUBXTVfZ+yR7Zjez3qjBz6i9+i4zjNaoqcoFVI4lQJ5plg63TvGfRSDCRg==",
           "dev": true,
-          "optional": true,
           "requires": {
             "depd": "~1.1.2",
             "inherits": "2.0.3",
@@ -10099,8 +10035,7 @@
               "version": "2.0.3",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
               "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-              "dev": true,
-              "optional": true
+              "dev": true
             }
           }
         },
@@ -10108,8 +10043,7 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/http-https/-/http-https-1.0.0.tgz",
           "integrity": "sha1-L5CN1fHbQGjAWM1ubUzjkskTOJs=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "http-signature": {
           "version": "1.2.0",
@@ -11847,8 +11781,7 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
           "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "lru-cache": {
           "version": "3.2.0",
@@ -11972,8 +11905,7 @@
           "version": "0.3.0",
           "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
           "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "memdown": {
           "version": "1.4.1",
@@ -12150,8 +12082,7 @@
           "version": "1.6.0",
           "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
           "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "mime-db": {
           "version": "1.40.0",
@@ -12175,8 +12106,7 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
           "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "min-document": {
           "version": "2.19.0",
@@ -12215,7 +12145,6 @@
           "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
           "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -12617,7 +12546,6 @@
           "resolved": "https://registry.npmjs.org/number-to-bn/-/number-to-bn-1.7.0.tgz",
           "integrity": "sha1-uzYjWS9+X54AMLGXe9QaDFP+HqA=",
           "dev": true,
-          "optional": true,
           "requires": {
             "bn.js": "4.11.6",
             "strip-hex-prefix": "1.0.0"
@@ -12627,8 +12555,7 @@
               "version": "4.11.6",
               "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
               "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU=",
-              "dev": true,
-              "optional": true
+              "dev": true
             }
           }
         },
@@ -12973,7 +12900,6 @@
           "resolved": "https://registry.npmjs.org/oboe/-/oboe-2.1.4.tgz",
           "integrity": "sha1-IMiM2wwVNxuwQRklfU/dNLCqSfY=",
           "dev": true,
-          "optional": true,
           "requires": {
             "http-https": "^1.0.0"
           }
@@ -12983,7 +12909,6 @@
           "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
           "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
           "dev": true,
-          "optional": true,
           "requires": {
             "ee-first": "1.1.1"
           }
@@ -13208,8 +13133,7 @@
           "version": "1.3.3",
           "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
           "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "pascalcase": {
           "version": "0.1.1",
@@ -13611,15 +13535,13 @@
           "version": "6.7.0",
           "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
           "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "query-string": {
           "version": "5.1.1",
           "resolved": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
           "integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
           "dev": true,
-          "optional": true,
           "requires": {
             "decode-uri-component": "^0.2.0",
             "object-assign": "^4.1.0",
@@ -13657,15 +13579,13 @@
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
           "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "raw-body": {
           "version": "2.4.0",
           "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.0.tgz",
           "integrity": "sha512-4Oz8DUIwdvoa5qMJelxipzi/iJIi40O5cGV1wNYp5hvZP8ZN0T+jiNkL0QepXs+EsQ9XJ8ipEDoiH70ySUJP3Q==",
           "dev": true,
-          "optional": true,
           "requires": {
             "bytes": "3.1.0",
             "http-errors": "1.7.2",
@@ -14134,8 +14054,7 @@
           "version": "2.0.3",
           "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-2.0.3.tgz",
           "integrity": "sha1-uwBAvgMEPamgEqLOqfyfhSz8h9Q=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "scrypt.js": {
           "version": "0.3.0",
@@ -14226,7 +14145,6 @@
           "resolved": "https://registry.npmjs.org/send/-/send-0.17.1.tgz",
           "integrity": "sha512-BsVKsiGcQMFwT8UxypobUKyv7irCNRHk1T0G680vk88yf6LBByGcZJOTJCrTP2xVN6yI+XjPJcNuE3V4fT9sAg==",
           "dev": true,
-          "optional": true,
           "requires": {
             "debug": "2.6.9",
             "depd": "~1.1.2",
@@ -14248,7 +14166,6 @@
               "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
               "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
               "dev": true,
-              "optional": true,
               "requires": {
                 "ms": "2.0.0"
               },
@@ -14257,8 +14174,7 @@
                   "version": "2.0.0",
                   "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
                   "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-                  "dev": true,
-                  "optional": true
+                  "dev": true
                 }
               }
             },
@@ -14266,8 +14182,7 @@
               "version": "2.1.1",
               "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
               "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
-              "dev": true,
-              "optional": true
+              "dev": true
             }
           }
         },
@@ -14344,8 +14259,7 @@
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
           "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "sha.js": {
           "version": "2.4.11",
@@ -14387,15 +14301,13 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.0.tgz",
           "integrity": "sha1-c0TLuLbib7J9ZrL8hvn21Zl1IcY=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "simple-get": {
           "version": "2.8.1",
           "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-2.8.1.tgz",
           "integrity": "sha512-lSSHRSw3mQNUGPAYRqo7xy9dhKmxFXIjLjp4KHpf99GEH2VH7C3AM+Qfx6du6jhfUi6Vm7XnbEVEf7Wb6N8jRw==",
           "dev": true,
-          "optional": true,
           "requires": {
             "decompress-response": "^3.3.0",
             "once": "^1.3.1",
@@ -14782,8 +14694,7 @@
           "version": "1.5.0",
           "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
           "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "stream-browserify": {
           "version": "2.0.2",
@@ -14848,8 +14759,7 @@
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
           "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "string-argv": {
           "version": "0.0.2",
@@ -15161,7 +15071,6 @@
           "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.2.tgz",
           "integrity": "sha512-rzS0heiNf8Xn7/mpdSVVSMAWAoy9bfb1WOTYC78Z0UQKeKa/CWS8FOq0lKGNa8DWKAn9gxjCvMLYc5PGXYlK2A==",
           "dev": true,
-          "optional": true,
           "requires": {
             "bl": "^1.0.0",
             "buffer-alloc": "^1.2.0",
@@ -15379,8 +15288,7 @@
           "version": "4.0.1",
           "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
           "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "timers-browserify": {
           "version": "2.0.11",
@@ -15418,8 +15326,7 @@
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.1.1.tgz",
           "integrity": "sha512-lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "to-fast-properties": {
           "version": "1.0.3",
@@ -15485,8 +15392,7 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
           "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "toposort": {
           "version": "2.0.2",
@@ -15568,7 +15474,6 @@
           "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
           "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
           "dev": true,
-          "optional": true,
           "requires": {
             "media-typer": "0.3.0",
             "mime-types": "~2.1.24"
@@ -15778,8 +15683,7 @@
           "version": "1.9.1",
           "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.1.tgz",
           "integrity": "sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "undertaker": {
           "version": "1.2.1",
@@ -15858,8 +15762,7 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
           "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "unset-value": {
           "version": "1.0.0",
@@ -15950,8 +15853,7 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/url-set-query/-/url-set-query-1.0.0.tgz",
           "integrity": "sha1-AW6M/Xwg7gXK/neV6JK9BwL6ozk=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "url-to-options": {
           "version": "1.0.1",
@@ -15969,8 +15871,7 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/utf8/-/utf8-3.0.0.tgz",
           "integrity": "sha512-E8VjFIQ/TyQgp+TZfS6l8yp/xWppSAHzidGiRrqe4bK4XP9pTRyKFgGJpO3SN7zdX4DeomTrwaseCHovfpFcqQ==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "util": {
           "version": "0.10.3",
@@ -16047,8 +15948,7 @@
           "version": "1.1.2",
           "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
           "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "verror": {
           "version": "1.10.0",
@@ -16173,7 +16073,6 @@
           "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.2.4.tgz",
           "integrity": "sha512-CHc27sMuET2cs1IKrkz7xzmTdMfZpYswe7f0HcuyneTwS1yTlTnHyqjAaTy0ZygAb/x4iaVox+Gvr4oSAqSI+A==",
           "dev": true,
-          "optional": true,
           "requires": {
             "@types/bignumber.js": "^5.0.0",
             "@types/bn.js": "^4.11.4",
@@ -16188,8 +16087,7 @@
               "version": "12.12.14",
               "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.14.tgz",
               "integrity": "sha512-u/SJDyXwuihpwjXy7hOOghagLEV1KdAST6syfnOk6QZAMzZuWZqXy5aYYZbh8Jdpd4escVFP0MvftHNDb9pruA==",
-              "dev": true,
-              "optional": true
+              "dev": true
             }
           }
         },
@@ -16198,7 +16096,6 @@
           "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.2.4.tgz",
           "integrity": "sha512-U7wbsK8IbZvF3B7S+QMSNP0tni/6VipnJkB0tZVEpHEIV2WWeBHYmZDnULWcsS/x/jn9yKhJlXIxWGsEAMkjiw==",
           "dev": true,
-          "optional": true,
           "requires": {
             "underscore": "1.9.1",
             "web3-eth-iban": "1.2.4",
@@ -16210,7 +16107,6 @@
           "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.2.4.tgz",
           "integrity": "sha512-8p9kpL7di2qOVPWgcM08kb+yKom0rxRCMv6m/K+H+yLSxev9TgMbCgMSbPWAHlyiF3SJHw7APFKahK5Z+8XT5A==",
           "dev": true,
-          "optional": true,
           "requires": {
             "underscore": "1.9.1",
             "web3-core-helpers": "1.2.4",
@@ -16224,7 +16120,6 @@
           "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.2.4.tgz",
           "integrity": "sha512-gEUlm27DewUsfUgC3T8AxkKi8Ecx+e+ZCaunB7X4Qk3i9F4C+5PSMGguolrShZ7Zb6717k79Y86f3A00O0VAZw==",
           "dev": true,
-          "optional": true,
           "requires": {
             "any-promise": "1.3.0",
             "eventemitter3": "3.1.2"
@@ -16235,7 +16130,6 @@
           "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.2.4.tgz",
           "integrity": "sha512-eZJDjyNTDtmSmzd3S488nR/SMJtNnn/GuwxnMh3AzYCqG3ZMfOylqTad2eYJPvc2PM5/Gj1wAMQcRpwOjjLuPg==",
           "dev": true,
-          "optional": true,
           "requires": {
             "underscore": "1.9.1",
             "web3-core-helpers": "1.2.4",
@@ -16249,7 +16143,6 @@
           "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.2.4.tgz",
           "integrity": "sha512-3D607J2M8ymY9V+/WZq4MLlBulwCkwEjjC2U+cXqgVO1rCyVqbxZNCmHyNYHjDDCxSEbks9Ju5xqJxDSxnyXEw==",
           "dev": true,
-          "optional": true,
           "requires": {
             "eventemitter3": "3.1.2",
             "underscore": "1.9.1",
@@ -16283,7 +16176,6 @@
           "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.2.4.tgz",
           "integrity": "sha512-8eLIY4xZKoU3DSVu1pORluAw9Ru0/v4CGdw5so31nn+7fR8zgHMgwbFe0aOqWQ5VU42PzMMXeIJwt4AEi2buFg==",
           "dev": true,
-          "optional": true,
           "requires": {
             "ethers": "4.0.0-beta.3",
             "underscore": "1.9.1",
@@ -16294,15 +16186,13 @@
               "version": "3.0.0",
               "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.0.0.tgz",
               "integrity": "sha1-4h3xCtbCBTKVvLuNq0Cwnb6ofk0=",
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "elliptic": {
               "version": "6.3.3",
               "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.3.3.tgz",
               "integrity": "sha1-VILZZG1UvLif19mU/J4ulWiHbj8=",
               "dev": true,
-              "optional": true,
               "requires": {
                 "bn.js": "^4.4.0",
                 "brorand": "^1.0.1",
@@ -16315,7 +16205,6 @@
               "resolved": "https://registry.npmjs.org/ethers/-/ethers-4.0.0-beta.3.tgz",
               "integrity": "sha512-YYPogooSknTwvHg3+Mv71gM/3Wcrx+ZpCzarBj3mqs9njjRkrOo2/eufzhHloOCo3JSoNI4TQJJ6yU5ABm3Uog==",
               "dev": true,
-              "optional": true,
               "requires": {
                 "@types/node": "^10.3.2",
                 "aes-js": "3.0.0",
@@ -16334,7 +16223,6 @@
               "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
               "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
               "dev": true,
-              "optional": true,
               "requires": {
                 "inherits": "^2.0.3",
                 "minimalistic-assert": "^1.0.0"
@@ -16344,22 +16232,19 @@
               "version": "0.5.7",
               "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
               "integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc=",
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "setimmediate": {
               "version": "1.0.4",
               "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.4.tgz",
               "integrity": "sha1-IOgd5iLUoCWIzgyNqJc8vPHTE48=",
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "uuid": {
               "version": "2.0.1",
               "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
               "integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w=",
-              "dev": true,
-              "optional": true
+              "dev": true
             }
           }
         },
@@ -16403,7 +16288,6 @@
           "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.2.4.tgz",
           "integrity": "sha512-b/9zC0qjVetEYnzRA1oZ8gF1OSSUkwSYi5LGr4GeckLkzXP7osEnp9lkO/AQcE4GpG+l+STnKPnASXJGZPgBRQ==",
           "dev": true,
-          "optional": true,
           "requires": {
             "@types/bn.js": "^4.11.4",
             "underscore": "1.9.1",
@@ -16438,7 +16322,6 @@
           "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.2.4.tgz",
           "integrity": "sha512-D9HIyctru/FLRpXakRwmwdjb5bWU2O6UE/3AXvRm6DCOf2e+7Ve11qQrPtaubHfpdW3KWjDKvlxV9iaFv/oTMQ==",
           "dev": true,
-          "optional": true,
           "requires": {
             "bn.js": "4.11.8",
             "web3-utils": "1.2.4"
@@ -16449,7 +16332,6 @@
           "resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.2.4.tgz",
           "integrity": "sha512-5Russ7ZECwHaZXcN3DLuLS7390Vzgrzepl4D87SD6Sn1DHsCZtvfdPIYwoTmKNp69LG3mORl7U23Ga5YxqkICw==",
           "dev": true,
-          "optional": true,
           "requires": {
             "@types/node": "^12.6.1",
             "web3-core": "1.2.4",
@@ -16463,8 +16345,7 @@
               "version": "12.12.14",
               "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.14.tgz",
               "integrity": "sha512-u/SJDyXwuihpwjXy7hOOghagLEV1KdAST6syfnOk6QZAMzZuWZqXy5aYYZbh8Jdpd4escVFP0MvftHNDb9pruA==",
-              "dev": true,
-              "optional": true
+              "dev": true
             }
           }
         },
@@ -16473,7 +16354,6 @@
           "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.2.4.tgz",
           "integrity": "sha512-wKOsqhyXWPSYTGbp7ofVvni17yfRptpqoUdp3SC8RAhDmGkX6irsiT9pON79m6b3HUHfLoBilFQyt/fTUZOf7A==",
           "dev": true,
-          "optional": true,
           "requires": {
             "web3-core": "1.2.4",
             "web3-core-method": "1.2.4",
@@ -16730,7 +16610,6 @@
           "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.2.4.tgz",
           "integrity": "sha512-dzVCkRrR/cqlIrcrWNiPt9gyt0AZTE0J+MfAu9rR6CyIgtnm1wFUVVGaxYRxuTGQRO4Dlo49gtoGwaGcyxqiTw==",
           "dev": true,
-          "optional": true,
           "requires": {
             "web3-core-helpers": "1.2.4",
             "xhr2-cookies": "1.1.0"
@@ -16741,7 +16620,6 @@
           "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.2.4.tgz",
           "integrity": "sha512-8J3Dguffin51gckTaNrO3oMBo7g+j0UNk6hXmdmQMMNEtrYqw4ctT6t06YOf9GgtOMjSAc1YEh3LPrvgIsR7og==",
           "dev": true,
-          "optional": true,
           "requires": {
             "oboe": "2.1.4",
             "underscore": "1.9.1",
@@ -16753,7 +16631,6 @@
           "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.2.4.tgz",
           "integrity": "sha512-F/vQpDzeK+++oeeNROl1IVTufFCwCR2hpWe5yRXN0ApLwHqXrMI7UwQNdJ9iyibcWjJf/ECbauEEQ8CHgE+MYQ==",
           "dev": true,
-          "optional": true,
           "requires": {
             "@web3-js/websocket": "^1.0.29",
             "underscore": "1.9.1",
@@ -16778,7 +16655,6 @@
           "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.4.tgz",
           "integrity": "sha512-+S86Ip+jqfIPQWvw2N/xBQq5JNqCO0dyvukGdJm8fEWHZbckT4WxSpHbx+9KLEWY4H4x9pUwnoRkK87pYyHfgQ==",
           "dev": true,
-          "optional": true,
           "requires": {
             "bn.js": "4.11.8",
             "eth-lib": "0.2.7",
@@ -16795,7 +16671,6 @@
               "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
               "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
               "dev": true,
-              "optional": true,
               "requires": {
                 "bn.js": "^4.11.6",
                 "elliptic": "^6.4.0",
@@ -17201,7 +17076,6 @@
           "resolved": "https://registry.npmjs.org/xhr-request/-/xhr-request-1.1.0.tgz",
           "integrity": "sha512-Y7qzEaR3FDtL3fP30k9wO/e+FBnBByZeybKOhASsGP30NIkRAAkKD/sCnLvgEfAIEC1rcmK7YG8f4oEnIrrWzA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "buffer-to-arraybuffer": "^0.0.5",
             "object-assign": "^4.1.1",
@@ -17217,7 +17091,6 @@
           "resolved": "https://registry.npmjs.org/xhr-request-promise/-/xhr-request-promise-0.1.2.tgz",
           "integrity": "sha1-NDxE0e53JrhkgGloLQ+EDIO0Jh0=",
           "dev": true,
-          "optional": true,
           "requires": {
             "xhr-request": "^1.0.1"
           }
@@ -17227,7 +17100,6 @@
           "resolved": "https://registry.npmjs.org/xhr2-cookies/-/xhr2-cookies-1.1.0.tgz",
           "integrity": "sha1-fXdEnQmZGX8VXLc7I99yUF7YnUg=",
           "dev": true,
-          "optional": true,
           "requires": {
             "cookiejar": "^2.1.1"
           }

--- a/packages/ethereum-payments/src/BaseEthereumPayments.ts
+++ b/packages/ethereum-payments/src/BaseEthereumPayments.ts
@@ -120,11 +120,11 @@ implements BasePayments
     const isMain = (feeOption.feeRateType === FeeRateType.Main)
 
     const gasPrice = isWeight
-      ? feeOption.feeRate
+      ? (new BigNumber(feeOption.feeRate)).toFixed(0, 7)
       : (new BigNumber(feeOption.feeRate)).dividedBy(amountOfGas).toString()
     const fee = isWeight
       ? (new BigNumber(feeOption.feeRate)).multipliedBy(amountOfGas).toString()
-      : feeOption.feeRate
+      : (new BigNumber(feeOption.feeRate)).toFixed(0, 7)
 
     return {
       targetFeeRate:     feeOption.feeRate,
@@ -151,7 +151,7 @@ implements BasePayments
       targetFeeRateType: FeeRateType.BasePerWeight,
       feeBase,
       feeMain: this.toMainDenomination(feeBase),
-      gasPrice: targetFeeRate,
+      gasPrice: (new BigNumber(targetFeeRate)).toFixed(0, 7),
     }
   }
 

--- a/packages/ethereum-payments/src/EthereumPaymentsUtils.ts
+++ b/packages/ethereum-payments/src/EthereumPaymentsUtils.ts
@@ -39,7 +39,7 @@ export class EthereumPaymentsUtils implements PaymentsUtils {
   }
 
   toBaseDenomination(amount: Numeric): string {
-    return (this.toBaseDenominationBigNumber(amount)).toString(10)
+    return (this.toBaseDenominationBigNumber(amount)).toFixed(0, 7)
   }
 
   async isValidAddress(address: string): Promise<boolean> {

--- a/packages/ethereum-payments/test/EthereumPaymentsUtils.test.ts
+++ b/packages/ethereum-payments/test/EthereumPaymentsUtils.test.ts
@@ -20,6 +20,7 @@ describe('EthereumPaymentsUtils', () => {
     test('denominates eth in wei', () => {
       expect(epu.toBaseDenomination('1')).toBe('1000000000000000000')
       expect(epu.toBaseDenomination(1)).toBe('1000000000000000000')
+      expect(epu.toBaseDenomination('1.00000000000000000005')).toBe('1000000000000000000')
     })
   })
 

--- a/packages/payments-common/src/utils.ts
+++ b/packages/payments-common/src/utils.ts
@@ -40,7 +40,7 @@ export function createUnitConverters(decimals: number) {
   }
 
   function toBaseDenominationString(mainNumeric: Numeric): string {
-    return toBaseDenominationBigNumber(mainNumeric).toString()
+    return toBaseDenominationBigNumber(mainNumeric).toFixed(0, 7)
   }
 
   function toBaseDenominationNumber(mainNumeric: Numeric): number {


### PR DESCRIPTION
I think it would also be better to remove and not use `toBaseDenominationNumber`

Signed-off-by: Denys Bitaccess <denys@bitaccess.co>

## Subject

Description
