### PR TITLE
[feat](erc20) use eth const denomination for tx fee

### DIFF
--- a/packages/ethereum-payments/test/erc20/end-to-end.test.ts
+++ b/packages/ethereum-payments/test/erc20/end-to-end.test.ts
@@ -159,6 +159,7 @@ describe('end to end tests', () => {
       const destination = depositAddresses[0]
 
       const preBalanceSource = await hd.getBalance(source.address)
+      const preConfig = hd.getFullConfig()
 
       const unsignedTx = await hd.createTransaction(0, { address: destination }, '163331000')
       const signedTx = await hd.signTransaction(unsignedTx)
@@ -170,6 +171,7 @@ describe('end to end tests', () => {
 
       expect(balanceTarget).toEqual('163331000')
       expect(balanceSource).toEqual('6336669000')
+      expect(preConfig).toEqual(hd.getFullConfig())
     })
 
     test('sweep transaction', async () => {


### PR DESCRIPTION
I think that chances that eth to wei conversion will change are quite low so using hardcoded constant here

Signed-off-by: Denys Bitaccess <denys@bitaccess.co>