### PR TITLE
[fix] (bitcoin) Handle invalid confirmations count

### DIFF
--- a/packages/bitcoin-payments/src/bitcoinish/BitcoinishPayments.ts
+++ b/packages/bitcoin-payments/src/bitcoinish/BitcoinishPayments.ts
@@ -656,6 +656,12 @@ export abstract class BitcoinishPayments<Config extends BaseConfig> extends Bitc
     const confirmationId = tx.blockHash || null
     const confirmationNumber = tx.blockHeight ? String(tx.blockHeight) : undefined
     const confirmationTimestamp = tx.blockTime ? new Date(tx.blockTime * 1000) : null
+    if (tx.confirmations > 0x7FFFFFFF) {
+      // If confirmations exceeds the max value of a signed 32 bit integer, assume we have bad data
+      // Blockbook sometimes returns a confirmations count equal to `0xFFFFFFFF`
+      // Bitcoin won't have that many confirmations for 40,000 years
+      throw new Error(`Blockbook returned confirmations count for tx ${txId} that's way too big to be real (${confirmations})`)
+    }
     const isConfirmed = Boolean(tx.confirmations && tx.confirmations > 0)
     const status = isConfirmed ? TransactionStatus.Confirmed : TransactionStatus.Pending
     const amountSat = get(tx, 'vout.0.value', tx.value)


### PR DESCRIPTION
A couple of blockbook nodes have been returning `0xFFFFFFFF` for confirmations count.

See: https://btc5.trezor.io/api/tx/7d16430cae2b10b30768690769ce79b58f88f1a9c4a5bf3cefde4c6207933809

Same result for btc4, but not for btc1, btc2, and btc3