### PR TITLE
[feat](erc20) no toFixed conversion for targetFeeRate field in custom…

### DIFF
--- a/packages/ethereum-payments/src/erc20/BaseErc20Payments.ts
+++ b/packages/ethereum-payments/src/erc20/BaseErc20Payments.ts
@@ -348,7 +348,7 @@ export abstract class BaseErc20Payments <Config extends BaseErc20PaymentsConfig>
       : (new BigNumber(feeOption.feeRate)).toFixed(0, 7)
 
     return {
-      targetFeeRate:     (new BigNumber(feeOption.feeRate)).toFixed(0, 7),
+      targetFeeRate:     feeOption.feeRate,
       targetFeeLevel:    FeeLevel.Custom,
       targetFeeRateType: feeOption.feeRateType,
       feeBase:           isMain ? this.toBaseDenominationEth(fee) : fee,


### PR DESCRIPTION
… fee

Signed-off-by: Denys Bitaccess <denys@bitaccess.co>

Implemented by direct analogy with Eth fee methods.