### PR TITLE
[fix] (ethereum) Prefix signed tx id with 0x and return null for unsigned

### DIFF
--- a/packages/ethereum-payments/src/BaseEthereumPayments.ts
+++ b/packages/ethereum-payments/src/BaseEthereumPayments.ts
@@ -460,7 +460,7 @@ implements BasePayments
       }
 
     return {
-      id: '',
+      id: null,
       status: TransactionStatus.Unsigned,
       fromAddress: fromPayport.address,
       fromIndex: from,

--- a/packages/ethereum-payments/src/BaseEthereumPayments.ts
+++ b/packages/ethereum-payments/src/BaseEthereumPayments.ts
@@ -376,10 +376,10 @@ implements BasePayments
 
     return {
       ...unsignedTx,
-      id: tx.hash().toString('hex'),
+      id: `0x${tx.hash().toString('hex')}`,
       status: TransactionStatus.Signed,
       data: {
-        hex: '0x'+tx.serialize().toString('hex')
+        hex: `0x${tx.serialize().toString('hex')}`
       }
     }
   }

--- a/packages/ethereum-payments/src/erc20/BaseErc20Payments.ts
+++ b/packages/ethereum-payments/src/erc20/BaseErc20Payments.ts
@@ -121,7 +121,7 @@ export abstract class BaseErc20Payments <Config extends BaseErc20PaymentsConfig>
 
     return {
       status: TransactionStatus.Unsigned,
-      id: '',
+      id: null,
       fromAddress: fromTo.fromAddress,
       toAddress: fromTo.toAddress,
       toExtraId: null,
@@ -196,7 +196,7 @@ export abstract class BaseErc20Payments <Config extends BaseErc20PaymentsConfig>
 
     return {
       status: TransactionStatus.Unsigned,
-      id: '',
+      id: null,
       fromAddress: fromTo.fromAddress,
       toAddress: fromTo.toAddress,
       toExtraId: null,

--- a/packages/ethereum-payments/src/types.ts
+++ b/packages/ethereum-payments/src/types.ts
@@ -131,7 +131,6 @@ export type EthereumTransactionOptions = t.TypeOf<typeof EthereumTransactionOpti
 export const EthereumUnsignedTransaction = extendCodec(
   BaseUnsignedTransaction,
   {
-    id: t.string,
     amount: t.string,
     fee: t.string,
   },

--- a/packages/ethereum-payments/test/HdEthereumPayments.test.ts
+++ b/packages/ethereum-payments/test/HdEthereumPayments.test.ts
@@ -536,7 +536,7 @@ describe('HdEthereumPayments', () => {
         const res = await hdEP.createTransaction(from, to, amountEth)
 
         expect(res).toStrictEqual({
-          id: '',
+          id: null,
           status: 'unsigned',
           fromAddress: FROM_ADDRESS,
           toAddress: TO_ADDRESS,
@@ -628,7 +628,7 @@ describe('HdEthereumPayments', () => {
         const transactionValueEth = (new BigNumber(hdEP.toMainDenomination(balance))).minus(feeEth).toString()
 
         expect(res).toStrictEqual({
-          id: '',
+          id: null,
           status: 'unsigned',
           fromAddress: FROM_ADDRESS,
           toAddress: to.address,
@@ -702,7 +702,7 @@ describe('HdEthereumPayments', () => {
         const amountEth = '0.576'
 
         const unsignedTx = {
-          id: '',
+          id: null,
           status: 'unsigned',
           fromAddress: FROM_ADDRESS,
           toAddress: TO_ADDRESS,
@@ -728,7 +728,7 @@ describe('HdEthereumPayments', () => {
         const res = await hdEP.signTransaction(unsignedTx)
 
         expect(res).toStrictEqual({
-          id: '3137b3336975aabfcf141469727d8d805f5e6d343de7fcc93e61d8d19d5d238f',
+          id: '0x3137b3336975aabfcf141469727d8d805f5e6d343de7fcc93e61d8d19d5d238f',
           status: 'signed',
           fromAddress: FROM_ADDRESS,
           toAddress: to.address,


### PR DESCRIPTION
Fixes the following error seen when querying for a tx hash that doesn't have 0x prefix
`invalid argument 0: json: cannot unmarshal hex string without 0x prefix into Go value of type common.Hash`
And eliminates the following gringotts warning about seeing an empty string txid
`Adjusting externalId from  to b58f`