### PR TITLE
Fix/ethereum rounding

### DIFF
--- a/packages/ethereum-payments/test/HdEthereumPayments.test.ts
+++ b/packages/ethereum-payments/test/HdEthereumPayments.test.ts
@@ -204,16 +204,16 @@ describe('HdEthereumPayments', () => {
         })
 
         const resBase = await hdEP.resolveFeeOption({
-          feeRate: '1',
+          feeRate: '1000000000000000001',
           feeRateType: FeeRateType.Base,
         } as FeeOption)
         expect(resBase).toStrictEqual({
-          targetFeeRate: '1',
-          gasPrice: '0',
+          targetFeeRate: '1000000000000000001',
+          gasPrice: '20000000000000',
           targetFeeLevel: 'custom',
           targetFeeRateType: FeeRateType.Base,
-          feeBase: '1',
-          feeMain: '0.000000000000000001',
+          feeBase: '1000000000000000000',
+          feeMain: '1',
         })
       })
 


### PR DESCRIPTION
This fixes rounding issue that caused gas * price + amount to exceed available balance. Summary is:
- Calculate gas price based on input option
- Make sure that price is a whole number by rounding down
- Calculate total fees that gas price would imply

Implications: sometimes feeBase/feeMain will be a negligible amount lower than targetFeeRate due to rounding. However they should never exceed it