### PR TITLE
[fix] (eth|erc20) use checksummed addresses only

### DIFF
--- a/packages/ethereum-payments/src/BaseEthereumPayments.ts
+++ b/packages/ethereum-payments/src/BaseEthereumPayments.ts
@@ -1,6 +1,7 @@
 import { BigNumber } from 'bignumber.js'
 import { Transaction as Tx } from 'ethereumjs-tx'
 import Web3 from 'web3'
+const web3 = new Web3()
 import { TransactionReceipt } from 'web3-core';
 import { Eth } from 'web3-eth'
 import { cloneDeep } from 'lodash'
@@ -82,7 +83,7 @@ implements BasePayments
       if (!await this.isValidAddress(payport)) {
         throw new Error(`Invalid Ethereum address: ${payport}`)
       }
-      return { address: payport }
+      return { address: web3.utils.toChecksumAddress(payport) }
     }
 
     if (!await this.isValidPayport(payport)) {
@@ -92,7 +93,8 @@ implements BasePayments
         throw new Error(`Invalid Ethereum payport: ${JSON.stringify(payport)}`)
       }
     }
-    return payport
+
+    return Object.assign({}, payport, { address: web3.utils.toChecksumAddress(payport.address)})
   }
 
   async resolveFromTo(from: number, to: ResolveablePayport): Promise<FromTo> {
@@ -247,8 +249,8 @@ implements BasePayments
     if (!txInfo) {
       txInfo = {
         transactionHash: tx.hash,
-        from: tx.from || '',
-        to: tx.to || '',
+        from: tx.from ? web3.utils.toChecksumAddress(tx.from) : '',
+        to: tx.to ? web3.utils.toChecksumAddress(tx.to) : '',
         status: true,
         blockNumber: 0,
         cumulativeGasUsed: 0,
@@ -262,8 +264,8 @@ implements BasePayments
       return {
         id: txid,
         amount: this.toMainDenomination(tx.value),
-        toAddress: tx.to,
-        fromAddress: tx.from,
+        toAddress: tx.to ? web3.utils.toChecksumAddress(tx.to) : null,
+        fromAddress: tx.from ? web3.utils.toChecksumAddress(tx.from) : null,
         toExtraId: null,
         fromIndex: null,
         toIndex: null,
@@ -309,8 +311,8 @@ implements BasePayments
     return {
       id: txid,
       amount: this.toMainDenomination(tx.value),
-      toAddress: tx.to,
-      fromAddress: tx.from,
+      toAddress: tx.to ? web3.utils.toChecksumAddress(tx.to) : null,
+      fromAddress: tx.from ? web3.utils.toChecksumAddress(tx.from) : null,
       toExtraId: null,
       fromIndex: null,
       toIndex: null,

--- a/packages/ethereum-payments/src/EthereumPaymentsUtils.ts
+++ b/packages/ethereum-payments/src/EthereumPaymentsUtils.ts
@@ -103,7 +103,7 @@ export class EthereumPaymentsUtils implements PaymentsUtils {
       key = `0x${prv}`
     }
 
-    return web3.eth.accounts.privateKeyToAccount(key).address
+    return web3.utils.toChecksumAddress(web3.eth.accounts.privateKeyToAccount(key).address)
   }
 
   private async _getPayportValidationMessage(payport: Payport): Promise<string | undefined> {

--- a/packages/ethereum-payments/src/KeyPairEthereumPayments.ts
+++ b/packages/ethereum-payments/src/KeyPairEthereumPayments.ts
@@ -27,7 +27,7 @@ export class KeyPairEthereumPayments extends BaseEthereumPayments<KeyPairEthereu
       if (web3.utils.isAddress(value)) {
         address = value
       } else if (this.isValidPrivateKey(value)) {
-        address = this.privateKeyToAddress(value).toLowerCase()
+        address = this.privateKeyToAddress(value)
       } else if (this.isValidXprv(value)) {
         // XXX hardened
         const signatory = deriveSignatory(value)

--- a/packages/ethereum-payments/src/bip44.ts
+++ b/packages/ethereum-payments/src/bip44.ts
@@ -1,3 +1,5 @@
+import Web3 from 'web3'
+const web3 = new Web3()
 import { EthereumSignatory } from './types'
 import { pubToAddress } from 'ethereumjs-util'
 import { fromBase58, fromSeed } from 'bip32'
@@ -34,7 +36,7 @@ class EthereumBIP44 {
     const derived = this.deriveByIndex(index)
     let address = pubToAddress(derived.publicKey, true)
 
-    return `0x${address.toString('hex')}`
+    return web3.utils.toChecksumAddress(`0x${address.toString('hex')}`)
   }
 
   getPrivateKey(index?: number): string {

--- a/packages/ethereum-payments/test/EthereumPaymentsUtils.test.ts
+++ b/packages/ethereum-payments/test/EthereumPaymentsUtils.test.ts
@@ -166,7 +166,7 @@ describe('EthereumPaymentsUtils', () => {
 
   describe('privateKeyToAddress', () => {
     test('converts address for given private key', async () => {
-      expect(epu.privateKeyToAddress(VALID_PRVKEY).toLowerCase()).toBe(VALID_ADDRESS)
+      expect(epu.privateKeyToAddress(VALID_PRVKEY)).toBe(VALID_ADDRESS)
     })
   })
 })

--- a/packages/ethereum-payments/test/HdEthereumPayments.test.ts
+++ b/packages/ethereum-payments/test/HdEthereumPayments.test.ts
@@ -253,7 +253,7 @@ describe('HdEthereumPayments', () => {
         const transactionCountMocks = getTransactionCountMocks(2, FROM_ADDRESS, '0x1a')
         nockI.post(/.*/, transactionCountMocks.req).reply(200, transactionCountMocks.res)
 
-        expect(await hdEP.getNextSequenceNumber(FROM_ADDRESS)).toBe('27')
+        expect(await hdEP.getNextSequenceNumber(FROM_ADDRESS)).toBe('26')
       })
     })
 
@@ -273,10 +273,6 @@ describe('HdEthereumPayments', () => {
         nockI.post(/.*/, mockTransactionReceipt.req).reply(200, mockTransactionReceipt.res)
 
         const res = await hdEP.getTransactionInfo(txId)
-        res.toAddress = res.toAddress.toLowerCase()
-        res.data.to = res.data.to.toLowerCase()
-        res.fromAddress = res.fromAddress.toLowerCase()
-        res.data.from = res.data.from.toLowerCase()
 
         expect(res).toStrictEqual({
           id: txId,
@@ -336,10 +332,6 @@ describe('HdEthereumPayments', () => {
         nockI.post(/.*/, mockBlockByNumber.req).reply(200, mockBlockByNumber.res)
 
         const res = await hdEP.getTransactionInfo(txId)
-        res.toAddress = res.toAddress.toLowerCase()
-        res.data.to = res.data.to.toLowerCase()
-        res.fromAddress = res.fromAddress.toLowerCase()
-        res.data.from = res.data.from.toLowerCase()
 
         expect(res).toStrictEqual({
           id: txId,
@@ -399,10 +391,6 @@ describe('HdEthereumPayments', () => {
         nockI.post(/.*/, mockBlockByNumber.req).reply(200, mockBlockByNumber.res)
 
         const res = await hdEP.getTransactionInfo(txId)
-        res.toAddress = res.toAddress.toLowerCase()
-        res.data.to = res.data.to.toLowerCase()
-        res.fromAddress = res.fromAddress.toLowerCase()
-        res.data.from = res.data.from.toLowerCase()
 
         expect(res).toStrictEqual({
           id: txId,
@@ -462,10 +450,6 @@ describe('HdEthereumPayments', () => {
         })
 
         const res = await hdEP.getTransactionInfo(txId)
-        res.toAddress = res.toAddress.toLowerCase()
-        res.data.to = res.data.to.toLowerCase()
-        res.fromAddress = res.fromAddress.toLowerCase()
-        res.data.from = res.data.from.toLowerCase()
 
         expect(res).toStrictEqual({
           id: txId,
@@ -548,14 +532,14 @@ describe('HdEthereumPayments', () => {
           targetFeeLevel: 'medium',
           targetFeeRate: '3000000000',
           targetFeeRateType: 'base/weight',
-          sequenceNumber: '27',
+          sequenceNumber: '26',
           data: {
             from: FROM_ADDRESS,
             to: TO_ADDRESS,
             value: '0x11c37937e08000',
             gas: '0xc350',
             gasPrice: '0xb2d05e00',
-            nonce: '0x1b'
+            nonce: '0x1a'
           }
         })
 
@@ -640,14 +624,14 @@ describe('HdEthereumPayments', () => {
           targetFeeLevel: 'medium',
           targetFeeRate: '3000000000',
           targetFeeRateType: 'base/weight',
-          sequenceNumber: '27',
+          sequenceNumber: '26',
           data: {
             from: FROM_ADDRESS,
             to: to.address,
             value: '0x1f955d1afcee972',
             gas: '0x7c1a',
             gasPrice: '0xb2d05e00',
-            nonce: '0x1b'
+            nonce: '0x1a'
           }
         })
 

--- a/packages/ethereum-payments/test/NetworkData.test.ts
+++ b/packages/ethereum-payments/test/NetworkData.test.ts
@@ -48,7 +48,7 @@ describe('NetworkData', () => {
     expect(res).toEqual({
       'pricePerGasUnit': '1000000000',
       'amountOfGas': '50000',
-      'nonce': '27',
+      'nonce': '26',
     })
   })
 

--- a/packages/ethereum-payments/test/NetworkData.test.ts
+++ b/packages/ethereum-payments/test/NetworkData.test.ts
@@ -27,7 +27,7 @@ describe('NetworkData', () => {
   const nockI = nock(INFURA_URL)
 
   const Web3 = require('web3')
-  const web3 = new Web3()
+  const web3 = new Web3(INFURA_URL)
 
   const from = web3.eth.accounts.create().address
   const to = web3.eth.accounts.create().address

--- a/packages/ethereum-payments/test/erc20/end-to-end.test.ts
+++ b/packages/ethereum-payments/test/erc20/end-to-end.test.ts
@@ -25,7 +25,7 @@ const factory = new EthereumPaymentsFactory()
 const source = hdAccount.child0Child[0]
 
 const tokenIssuer =  {
-  address: '0xfdc7c2aeba72d3f4689f995698ec44bcdfa854e8',
+  address: '0xFDc7C2aeba72D3F4689f995698eC44bcdfa854e8',
   keys: {
     prv: '0xfabbf3c5bffd9c3cebe86fb82ce7618026c59ce3ba6933bae00758e6ca22434c',
     pub: '03e1d562c90ab342dcc26b0c3edf1b197cfe39247d34790f7e37e7d45ebd0f2204'
@@ -37,7 +37,7 @@ const tokenIssuer =  {
 }
 
 const tokenDistributor = {
-  address: '0x01bb0fdded631a75f841e4b3c493d4dd345d5f7d',
+  address: '0x01bB0FddED631A75f841e4b3C493D4dd345D5f7D',
   keys: {
     prv: '0xb55f2052f607b60b59e07687649a8c738b595896c199d582e7db9b15ace79d9a',
     pub: '038bd304e7cc1aa621d63046ce009f15e1bdb8ec3b7cbc65e52917f5870ddb0208'
@@ -67,19 +67,19 @@ jest.setTimeout(100000)
 describe('end to end tests', () => {
   let ethNode: any
   beforeAll(async () => {
-  const ganacheConfig = {
-    accounts: [
-      {
-        balance: 0xde0b6b3a764000, // 1 ETH
-        secretKey: tokenDistributor.keys.prv
-      },
-      {
-        balance: 0xde0b6b3a764000, // 1 ETH
-        secretKey: source.keys.prv
-      },
-    ], gasLimit: '0x9849ef',// 9980399
-    callGasLimit: '0x9849ef',// 9980399
-  }
+    const ganacheConfig = {
+      accounts: [
+        {
+          balance: 0xde0b6b3a764000, // 1 ETH
+          secretKey: tokenDistributor.keys.prv
+        },
+        {
+          balance: 0xde0b6b3a764000, // 1 ETH
+          secretKey: source.keys.prv
+        },
+      ], gasLimit: '0x9849ef',// 9980399
+      callGasLimit: '0x9849ef',// 9980399
+    }
 
     ethNode = server.server(ganacheConfig)
     ethNode.listen(LOCAL_PORT)
@@ -147,7 +147,7 @@ describe('end to end tests', () => {
 
         expect(txInfo)
         const data: any = txInfo.data
-        expect(data.from).toEqual(address)
+        expect(data.from).toEqual(address.toLowerCase())
         depositAddresses.push(data.contractAddress)
 
         const { confirmedBalance } = await hd.getBalance(data.contractAddress)

--- a/packages/ethereum-payments/test/fixtures/accounts.ts
+++ b/packages/ethereum-payments/test/fixtures/accounts.ts
@@ -8,7 +8,7 @@ export const hdAccount = {
   },
   rootChild: {
     0: {
-      address: '0x1dcec4457f145ea1b2fa54b3c4f0a2d81d6a1c92',
+      address: '0x1dCec4457F145eA1B2FA54B3c4F0A2d81D6a1C92',
       keys: {
         prv: '0x2c1c7f79f455b25b0d687ea4d464f58844a3c2a7ffed1c02a3e224f94ff50517',
         pub: '02c5028014e9ee4344319396db6e3f66fc52fb17fb636ff138a6b51a7f419f037b',
@@ -19,7 +19,7 @@ export const hdAccount = {
       },
     },
     1: {
-      address: '0x8f0bb36577b19da9826fc726fec2b4943c45e014',
+      address: '0x8f0bb36577B19da9826fC726fEc2b4943c45e014',
       keys: {
         prv: '0x8195f08756bdb4324748d622fc821d9ddc34eb249fe152bba7e5b4539aff9cad',
         pub: '0383f4af96bfbb731d2ca34b6c0ce5136980f2fbcc87494b8f46d480f4108ea090',
@@ -32,7 +32,7 @@ export const hdAccount = {
   },
   child0ChildPub: {
     0: {
-      address: '0x8df37c35795e61e50ff27d869a12fdad57f726b7',
+      address: '0x8df37c35795E61E50FF27d869A12FDAD57F726b7',
       keys: {
         prv: '',
         pub: '024bba31f2d404d982281b2a736853ef539cf1bfa4c03fdf24cffb90c943340324',
@@ -45,7 +45,7 @@ export const hdAccount = {
   },
   child0Child: {
     0: {
-      address: '0x8df37c35795e61e50ff27d869a12fdad57f726b7',
+      address: '0x8df37c35795E61E50FF27d869A12FDAD57F726b7',
       keys: {
         prv: '0xc8d72c60a76d483538d68b5a12c827668c30e404078a10bf740763cdf002a94f',
         pub: '024bba31f2d404d982281b2a736853ef539cf1bfa4c03fdf24cffb90c943340324'
@@ -58,7 +58,7 @@ export const hdAccount = {
   },
   child1Child: {
     0: {
-      address: '0x3869bc1cc712642be41ac39c6adcbbca5c475732',
+      address: '0x3869bc1cc712642Be41Ac39c6ADcBBCA5C475732',
       keys: {
         prv: '0x3118f5a69f0889df1f89aa5f39eebfb77521bb5ce4cd64f7bb598aa7977cfa65',
         pub: '02027f388a13822220311b381a6691d118f9eacf2c46bbc3a028d87605337f91e7'
@@ -69,7 +69,7 @@ export const hdAccount = {
       }
     },
     1: {
-      address: '0xf7d2eac7b9e0f55ec49c892815e6355517bc63db',
+      address: '0xF7d2Eac7B9E0F55eC49C892815e6355517bc63dB',
       keys: {
         prv: '0xa184594ec6aeebc44399e4b21bbdf07910fd93a6c1566aed03b874858d9798ce',
         pub: '029d2c5266e33a2ab5dc542e48e43f7fa5f99e9708f5f265b6967a5e6a62a0d5c7'
@@ -82,7 +82,7 @@ export const hdAccount = {
   },
   child1ChildPub: {
     0: {
-      address: '0x3869bc1cc712642be41ac39c6adcbbca5c475732',
+      address: '0x3869bc1cc712642Be41Ac39c6ADcBBCA5C475732',
       keys: {
         prv: '',
         pub: '02027f388a13822220311b381a6691d118f9eacf2c46bbc3a028d87605337f91e7'
@@ -93,7 +93,7 @@ export const hdAccount = {
       }
     },
     1: {
-      address: '0xf7d2eac7b9e0f55ec49c892815e6355517bc63db',
+      address: '0xF7d2Eac7B9E0F55eC49C892815e6355517bc63dB',
       keys: {
         prv: '',
         pub: '029d2c5266e33a2ab5dc542e48e43f7fa5f99e9708f5f265b6967a5e6a62a0d5c7',

--- a/packages/ethereum-payments/test/fixtures/mocks.ts
+++ b/packages/ethereum-payments/test/fixtures/mocks.ts
@@ -137,7 +137,7 @@ function getNextNonceRequest(id: number, address: string): Object {
   return {
     jsonrpc: '2.0',
     method:'parity_nextNonce',
-    params: [address],
+    params: [address.toLowerCase()],
     id
   }
 }
@@ -155,7 +155,7 @@ function getBalanceRequest(id: number, address: string): Object {
     jsonrpc:'2.0',
     id,
     method:'eth_getBalance',
-    params: [address, 'latest'],
+    params: [address.toLowerCase(), 'latest'],
   }
 }
 
@@ -171,7 +171,7 @@ function getTransactionCountRequest(id: number, address: string): Object {
   return {
     jsonrpc:'2.0',
     method:'eth_getTransactionCount',
-    params: [address, 'pending'],
+    params: [address.toLowerCase(), 'pending'],
     id,
   }
 }


### PR DESCRIPTION
* fix tests for nonce
* force lowercase in http mocks (web3 sends addresses out as lowercased)

Signed-off-by: Denys Bitaccess <denys@bitaccess.co>
