### PR TITLE
Fix web3 contract closure leak

### DIFF
--- a/packages/ethereum-payments/package-lock.json
+++ b/packages/ethereum-payments/package-lock.json
@@ -640,16 +640,6 @@
         "@ethersproject/signing-key": "^5.0.0"
       }
     },
-    "@faast/payments-common": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@faast/payments-common/-/payments-common-2.7.0.tgz",
-      "integrity": "sha512-IZ+uGC9Z7A3ktEoZtimtmGE+F+MHbGtD81JAsY47NBW+Gl3EGeVFFFQ+yZ+dYva3/JwBabhgrkCVo/L1f+sDRw==",
-      "requires": {
-        "@faast/ts-common": "^0.6.0",
-        "bignumber.js": "^9.0.0",
-        "io-ts": "^1.10.4"
-      }
-    },
     "@faast/ts-common": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/@faast/ts-common/-/ts-common-0.6.0.tgz",

--- a/packages/ethereum-payments/package.json
+++ b/packages/ethereum-payments/package.json
@@ -87,6 +87,7 @@
     "io-ts": "^1.10.4",
     "lodash": "^4.17.15",
     "request-promise-native": "^1.0.8",
-    "web3": "^1.2.11"
+    "web3": "^1.2.11",
+    "web3-eth-contract": "^1.2.11"
   }
 }

--- a/packages/ethereum-payments/src/@types/web3-eth-contract/index.d.ts
+++ b/packages/ethereum-payments/src/@types/web3-eth-contract/index.d.ts
@@ -1,0 +1,161 @@
+
+declare module 'web3-eth-contract' {
+  import BN = require('bn.js');
+  import {Common, PromiEvent, provider, hardfork, chain, BlockNumber, PastLogsOptions, LogsOptions} from 'web3-core';
+  import {AbiItem} from 'web3-utils';
+
+  // TODO: Add generic type!
+  export default class Contract {
+      constructor(
+          jsonInterface: AbiItem[],
+          address?: string,
+          options?: ContractOptions
+      );
+
+      private _address: string;
+      private _jsonInterface: AbiItem[];
+      defaultAccount: string | null;
+      defaultBlock: BlockNumber;
+      defaultCommon: Common;
+      defaultHardfork: hardfork;
+      defaultChain: chain;
+      transactionPollingTimeout: number;
+      transactionConfirmationBlocks: number;
+      transactionBlockTimeout: number;
+      handleRevert: boolean;
+
+      options: Options;
+
+      setProvider(provider: provider): true
+
+      clone(): Contract;
+
+      deploy(options: DeployOptions): ContractSendMethod;
+
+      methods: any;
+
+      once(
+          event: string,
+          callback: (error: Error, event: EventData) => void
+      ): void;
+      once(
+          event: string,
+          options: EventOptions,
+          callback: (error: Error, event: EventData) => void
+      ): void;
+
+      events: any;
+
+      getPastEvents(event: string): Promise<EventData[]>;
+      getPastEvents(
+          event: string,
+          options: PastEventOptions,
+          callback: (error: Error, event: EventData) => void
+      ): Promise<EventData[]>;
+      getPastEvents(event: string, options: PastEventOptions): Promise<EventData[]>;
+      getPastEvents(
+          event: string,
+          callback: (error: Error, event: EventData) => void
+      ): Promise<EventData[]>;
+  }
+
+  export interface Options extends ContractOptions {
+      address: string;
+      jsonInterface: AbiItem[];
+  }
+
+  export interface DeployOptions {
+      data: string;
+      arguments?: any[];
+  }
+
+  export interface ContractSendMethod {
+      send(
+          options: SendOptions,
+          callback?: (err: Error, transactionHash: string) => void
+      ): PromiEvent<Contract>;
+
+      call(
+          options?: CallOptions,
+          callback?: (err: Error, result: any) => void
+      ): Promise<any>;
+
+      estimateGas(
+          options: EstimateGasOptions,
+          callback?: (err: Error, gas: number) => void
+      ): Promise<number>;
+
+      estimateGas(callback: (err: Error, gas: number) => void): Promise<number>;
+
+      estimateGas(
+          options: EstimateGasOptions,
+          callback: (err: Error, gas: number) => void
+      ): Promise<number>;
+
+      estimateGas(options: EstimateGasOptions): Promise<number>;
+
+      estimateGas(): Promise<number>;
+
+      encodeABI(): string;
+  }
+
+  export interface CallOptions {
+      from?: string;
+      gasPrice?: string;
+      gas?: number;
+  }
+
+  export interface SendOptions {
+      from: string;
+      gasPrice?: string;
+      gas?: number;
+      value?: number | string | BN;
+  }
+
+  export interface EstimateGasOptions {
+      from?: string;
+      gas?: number;
+      value?: number | string | BN;
+  }
+
+  export interface ContractOptions {
+      // Sender to use for contract calls
+      from?: string;
+      // Gas price to use for contract calls
+      gasPrice?: string;
+      // Gas to use for contract calls
+      gas?: number;
+      // Contract code
+      data?: string;
+  }
+
+  export interface PastEventOptions extends PastLogsOptions {
+      filter?: Filter;
+  }
+
+  export interface EventOptions extends LogsOptions {
+      filter?: Filter;
+  }
+
+  export interface Filter {
+      [key: string]: number | string | string[] | number[];
+  }
+
+  export interface EventData {
+      returnValues: {
+          [key: string]: any;
+      };
+      raw: {
+          data: string;
+          topics: string[];
+      };
+      event: string;
+      signature: string;
+      logIndex: number;
+      transactionIndex: number;
+      transactionHash: string;
+      blockHash: string;
+      blockNumber: number;
+      address: string;
+  }
+}


### PR DESCRIPTION
Both web3 1.x and 2.x have a feature that supports changing the provider of all instantiated contracts using a single call to the web3.setProvider. To accomplish this a reference to every contract is retained by web3 when using `new web.eth.Contract` which on long running processes (ie a web server) will eventually lead to an OOM error. However, we can work around this by using the `web3-eth-contract` directly so that web3 doesn't retain the reference.

In this PR I also had to add augment type declarations because the provided ones were incomplete (`setProvider` was missing and the `Contract` class was not declared as the default export despite being so)

Fixes this relevant issue: https://github.com/ethereum/web3.js/issues/3042