### PR TITLE
[fix] Lower ERC20 gas limit maximums

### DIFF
--- a/packages/ethereum-payments/src/constants.ts
+++ b/packages/ethereum-payments/src/constants.ts
@@ -16,8 +16,8 @@ export const GAS_STATION_URL = 'https://ethgasstation.info'
 // The following are effective maximum gas amounts for various txs we send
 export const ETHEREUM_TRANSFER_COST = '50000'
 export const CONTRACT_DEPLOY_COST = '285839'
-export const TOKEN_SWEEP_COST = '816630'
-export const TOKEN_TRANSFER_COST = '250000'
+export const TOKEN_SWEEP_COST = '200000'
+export const TOKEN_TRANSFER_COST = '150000'
 
 /** Multiply all web3 estimateGas calls by this because it's innacurate */
 export const GAS_ESTIMATE_MULTIPLIER = 1.5


### PR DESCRIPTION
Not sure how these where originally determined but they're definitely too high