### PR TITLE
Return signerAddress in getPayport and refactor create2 address methods

### DIFF
--- a/packages/ethereum-payments/src/erc20/HdErc20Payments.ts
+++ b/packages/ethereum-payments/src/erc20/HdErc20Payments.ts
@@ -77,7 +77,8 @@ export class HdErc20Payments extends BaseErc20Payments<HdErc20PaymentsConfig> {
       // This should never happen
       throw new Error(`Cannot get address ${index} - validation failed for derived address`)
     }
-    return { address, signerAddress: signatory.address }
+    const { address: signerAddress } = deriveSignatory(this.getXpub(), this.depositKeyIndex)
+    return { address, signerAddress }
   }
 
   async getPrivateKey(index: number): Promise<string> {

--- a/packages/ethereum-payments/src/erc20/HdErc20Payments.ts
+++ b/packages/ethereum-payments/src/erc20/HdErc20Payments.ts
@@ -53,17 +53,31 @@ export class HdErc20Payments extends BaseErc20Payments<HdErc20PaymentsConfig> {
     return [this.getXpub()]
   }
 
-  // NOTE it is possible to use this.masterAddress
-  async getPayport(index: number, masterAddress?: string): Promise<Payport> {
-    const signatory = deriveSignatory(this.getXpub(), index)
-    const address = masterAddress ? deriveAddress(masterAddress, signatory.keys.pub) : signatory.address
+  getAddressSalt(index: number): string {
+    const key = deriveSignatory(this.getXpub(), index).keys.pub
+    const salt = this.web3.utils.sha3(`0x${key}`)
+    if (!salt) {
+      throw new Error(`Cannot get address salt for index ${index}`)
+    }
+    return salt
+  }
 
+  async getPayport(index: number): Promise<Payport> {
+    const signatory = deriveSignatory(this.getXpub(), index)
+    if (index === 0) {
+      return { address: signatory.address }
+    }
+
+    if (!this.masterAddress) {
+      throw new Error(`Cannot derive payport ${index} - masterAddress is falsy`)
+    }
+    const address = deriveAddress(this.masterAddress, signatory.keys.pub)
 
     if (!await this.isValidAddress(address)) {
       // This should never happen
       throw new Error(`Cannot get address ${index} - validation failed for derived address`)
     }
-    return { address }
+    return { address, signerAddress: signatory.address }
   }
 
   async getPrivateKey(index: number): Promise<string> {

--- a/packages/ethereum-payments/test/erc20/end-to-end.test.ts
+++ b/packages/ethereum-payments/test/erc20/end-to-end.test.ts
@@ -161,7 +161,7 @@ describe('end to end tests', () => {
       // NOTE: i != 0 because 0 is signer's index
       // proxy contracts of the first one
       for (let i = 1; i < 10; i++) {
-        const { address: derivedAddress } = await hd.getPayport(i, hd.masterAddress)
+        const { address: derivedAddress } = await hd.getPayport(i)
         const { confirmedBalance: dABalance } = await hd.getBalance(derivedAddress)
         expect(dABalance).toEqual('0')
         depositAddresses.push(derivedAddress)

--- a/packages/payments-common/src/types.ts
+++ b/packages/payments-common/src/types.ts
@@ -43,6 +43,7 @@ export const Payport = requiredOptionalCodec(
   },
   {
     extraId: nullable(t.string),
+    signerAddress: t.string,
   },
   'Payport',
 )


### PR DESCRIPTION
Include a new optional `signerAddress` field in `Payport` type. `getPayport` will use it to return the address responsible for signing transactions for the payport, when different from `address`.

Also refactored some of the create2 methods:
- Add `getAddressSalt` instead of `getXpub` to separate HD derivation responsibility from BaseErc20Payments
- Remove `masterAddress` param from `getPayport` to conform to the global API