### PR TITLE
Feat/blockcypher token

### DIFF
--- a/packages/bitcoin-payments/src/BaseBitcoinPayments.ts
+++ b/packages/bitcoin-payments/src/BaseBitcoinPayments.ts
@@ -21,10 +21,12 @@ import { BitcoinishPayments, BitcoinishPaymentTx } from './bitcoinish'
 export abstract class BaseBitcoinPayments<Config extends BaseBitcoinPaymentsConfig> extends BitcoinishPayments<Config> {
 
   readonly maximumFeeRate?: number
+  readonly blockcypherToken?: string
 
   constructor(config: BaseBitcoinPaymentsConfig) {
     super(toBitcoinishConfig(config))
     this.maximumFeeRate = config.maximumFeeRate
+    this.blockcypherToken = config.blockcypherToken
   }
 
   abstract getPaymentScript(index: number): bitcoin.payments.Payment
@@ -49,7 +51,7 @@ export abstract class BaseBitcoinPayments<Config extends BaseBitcoinPaymentsConf
   async getFeeRateRecommendation(feeLevel: AutoFeeLevels): Promise<FeeRate> {
     let satPerByte: number
     try {
-      satPerByte = await getBlockcypherFeeEstimate(feeLevel, this.networkType)
+      satPerByte = await getBlockcypherFeeEstimate(feeLevel, this.networkType, this.blockcypherToken)
     } catch (e) {
       satPerByte = DEFAULT_SAT_PER_BYTE_LEVELS[feeLevel]
       this.logger.warn(

--- a/packages/bitcoin-payments/src/BaseBitcoinPayments.ts
+++ b/packages/bitcoin-payments/src/BaseBitcoinPayments.ts
@@ -55,7 +55,7 @@ export abstract class BaseBitcoinPayments<Config extends BaseBitcoinPaymentsConf
     } catch (e) {
       satPerByte = DEFAULT_SAT_PER_BYTE_LEVELS[feeLevel]
       this.logger.warn(
-        `Failed to get bitcoin ${this.networkType} fee estimate, using hardcoded default of ${feeLevel} sat/byte -- ${e.message}`
+        `Failed to get bitcoin ${this.networkType} fee estimate, using hardcoded default of ${satPerByte} sat/byte -- ${e.message}`
       )
     }
     return {

--- a/packages/bitcoin-payments/src/HdBitcoinPayments.ts
+++ b/packages/bitcoin-payments/src/HdBitcoinPayments.ts
@@ -74,7 +74,7 @@ export class HdBitcoinPayments extends SinglesigBitcoinPayments<HdBitcoinPayment
 
   getPublicConfig(): HdBitcoinPaymentsConfig {
     return {
-      ...omit(this.getFullConfig(), ['logger', 'server', 'hdKey']),
+      ...omit(this.getFullConfig(), ['logger', 'server', 'hdKey', 'blockcypherToken']),
       hdKey: this.xpub,
     }
   }

--- a/packages/bitcoin-payments/src/KeyPairBitcoinPayments.ts
+++ b/packages/bitcoin-payments/src/KeyPairBitcoinPayments.ts
@@ -53,7 +53,7 @@ export class KeyPairBitcoinPayments extends SinglesigBitcoinPayments<KeyPairBitc
 
   getPublicConfig(): KeyPairBitcoinPaymentsConfig {
     return {
-      ...omit(this.getFullConfig(), ['logger', 'server', 'keyPairs']),
+      ...omit(this.getFullConfig(), ['logger', 'server', 'keyPairs', 'blockcypherToken']),
       keyPairs: this.publicKeys,
     }
   }

--- a/packages/bitcoin-payments/src/constants.ts
+++ b/packages/bitcoin-payments/src/constants.ts
@@ -54,7 +54,7 @@ export const DEFAULT_TESTNET_SERVER = process.env.BITCOIN_TESTNET_SERVER_URL
 
 export const DEFAULT_FEE_LEVEL = FeeLevel.Medium
 export const DEFAULT_SAT_PER_BYTE_LEVELS = {
-  [FeeLevel.High]: 50,
-  [FeeLevel.Medium]: 25,
-  [FeeLevel.Low]: 10,
+  [FeeLevel.High]: 100,
+  [FeeLevel.Medium]: 50,
+  [FeeLevel.Low]: 25,
 }

--- a/packages/bitcoin-payments/src/types.ts
+++ b/packages/bitcoin-payments/src/types.ts
@@ -64,6 +64,7 @@ export const BaseBitcoinPaymentsConfig = extendCodec(
     targetUtxoPoolSize: t.number, // # of available utxos to try and maintain
     minChange: t.string, // Soft minimum for each change generated to maintain utxo pool
     maximumFeeRate: t.number, // Hard sat/byte fee cap passed to Psbt constructor
+    blockcypherToken: t.string,
   },
   'BaseBitcoinPaymentsConfig',
 )

--- a/packages/bitcoin-payments/src/utils.ts
+++ b/packages/bitcoin-payments/src/utils.ts
@@ -58,9 +58,15 @@ export function toBitcoinishConfig<T extends BaseBitcoinPaymentsConfig>(config: 
 }
 
 /** Get sat/byte fee estimate from blockcypher */
-export async function getBlockcypherFeeEstimate(feeLevel: FeeLevel, networkType: NetworkType): Promise<number> {
+export async function getBlockcypherFeeEstimate(
+  feeLevel: FeeLevel,
+  networkType: NetworkType,
+  blockcypherToken?: string,
+): Promise<number> {
+  const networkParam = networkType === NetworkType.Mainnet ? 'main' : 'test3'
+  const tokenQs = blockcypherToken ? `?token=${blockcypherToken}` : ''
   const body = await request.get(
-    `https://api.blockcypher.com/v1/btc/${networkType === NetworkType.Mainnet ? 'main' : 'test3'}`,
+    `https://api.blockcypher.com/v1/btc/${networkParam}${tokenQs}`,
     { json: true },
   )
   const feePerKbField = `${feeLevel}_fee_per_kb`

--- a/packages/litecoin-payments/src/BaseLitecoinPayments.ts
+++ b/packages/litecoin-payments/src/BaseLitecoinPayments.ts
@@ -59,7 +59,7 @@ extends BitcoinishPayments<Config> {
     } catch (e) {
       satPerByte = DEFAULT_SAT_PER_BYTE_LEVELS[feeLevel]
       this.logger.warn(
-        `Failed to get litecoin ${this.networkType} fee estimate, using hardcoded default of ${feeLevel} sat/byte -- ${e.message}`
+        `Failed to get litecoin ${this.networkType} fee estimate, using hardcoded default of ${satPerByte} sat/byte -- ${e.message}`
       )
     }
     return {

--- a/packages/litecoin-payments/src/BaseLitecoinPayments.ts
+++ b/packages/litecoin-payments/src/BaseLitecoinPayments.ts
@@ -25,14 +25,16 @@ import {
 import { isValidAddress, isValidPrivateKey, isValidPublicKey } from './helpers'
 import { BitcoinishPayments, BitcoinishPaymentTx } from '@faast/bitcoin-payments'
 
-export abstract class BaseLitecoinPayments<Config extends BaseLitecoinPaymentsConfig> 
+export abstract class BaseLitecoinPayments<Config extends BaseLitecoinPaymentsConfig>
 extends BitcoinishPayments<Config> {
 
   readonly maximumFeeRate?: number
+  private readonly blockcypherToken?: string
 
   constructor(config: BaseLitecoinPaymentsConfig) {
     super(toBitcoinishConfig(config))
     this.maximumFeeRate = config.maximumFeeRate
+    this.blockcypherToken = config.blockcypherToken
   }
 
   abstract getPaymentScript(index: number): bitcoin.payments.Payment
@@ -53,7 +55,7 @@ extends BitcoinishPayments<Config> {
   async getFeeRateRecommendation(feeLevel: AutoFeeLevels): Promise<FeeRate> {
     let satPerByte: number
     try {
-      satPerByte = await getBlockcypherFeeEstimate(feeLevel, this.networkType)
+      satPerByte = await getBlockcypherFeeEstimate(feeLevel, this.networkType, this.blockcypherToken)
     } catch (e) {
       satPerByte = DEFAULT_SAT_PER_BYTE_LEVELS[feeLevel]
       this.logger.warn(

--- a/packages/litecoin-payments/src/HdLitecoinPayments.ts
+++ b/packages/litecoin-payments/src/HdLitecoinPayments.ts
@@ -75,7 +75,7 @@ export class HdLitecoinPayments extends SinglesigLitecoinPayments<HdLitecoinPaym
 
   getPublicConfig(): HdLitecoinPaymentsConfig {
     return {
-      ...omit(this.getFullConfig(), ['logger', 'server', 'hdKey']),
+      ...omit(this.getFullConfig(), ['logger', 'server', 'hdKey', 'blockcypherToken']),
       hdKey: this.xpub,
     }
   }

--- a/packages/litecoin-payments/src/KeyPairLitecoinPayments.ts
+++ b/packages/litecoin-payments/src/KeyPairLitecoinPayments.ts
@@ -53,7 +53,7 @@ export class KeyPairLitecoinPayments extends SinglesigLitecoinPayments<KeyPairLi
 
   getPublicConfig(): KeyPairLitecoinPaymentsConfig {
     return {
-      ...omit(this.getFullConfig(), ['logger', 'server', 'keyPairs']),
+      ...omit(this.getFullConfig(), ['logger', 'server', 'keyPairs', 'blockcypherToken']),
       keyPairs: this.publicKeys,
     }
   }

--- a/packages/litecoin-payments/src/types.ts
+++ b/packages/litecoin-payments/src/types.ts
@@ -64,6 +64,7 @@ export const BaseLitecoinPaymentsConfig = extendCodec(
     targetUtxoPoolSize: t.number, // # of available utxos to try and maintain
     minChange: t.string, // Soft minimum for each change generated to maintain utxo pool
     maximumFeeRate: t.number, // Hard sat/byte fee cap passed to Psbt constructor
+    blockcypherToken: t.string,
   },
   'BaseLitecoinPaymentsConfig',
 )

--- a/packages/litecoin-payments/src/utils.ts
+++ b/packages/litecoin-payments/src/utils.ts
@@ -58,9 +58,15 @@ export function toBitcoinishConfig<T extends BaseLitecoinPaymentsConfig>(config:
 }
 
 /** Get sat/byte fee estimate from blockcypher */
-export async function getBlockcypherFeeEstimate(feeLevel: FeeLevel, networkType: NetworkType): Promise<number> {
+export async function getBlockcypherFeeEstimate(
+  feeLevel: FeeLevel,
+  networkType: NetworkType,
+  blockcypherToken?: string,
+): Promise<number> {
+  const networkParam = networkType === NetworkType.Mainnet ? 'main' : 'test'
+  const tokenQs = blockcypherToken ? `?token=${blockcypherToken}` : ''
   const body = await request.get(
-    `https://api.blockcypher.com/v1/ltc/${networkType === NetworkType.Mainnet ? 'main' : 'test3'}`,
+    `https://api.blockcypher.com/v1/ltc/${networkParam}${tokenQs}`,
     { json: true },
   )
   const feePerKbField = `${feeLevel}_fee_per_kb`


### PR DESCRIPTION
Allows a blockcypher API token to be configured for fee estimate requests. Without a token rate limiting occurs occasionally causing fallback fee rate to be used more than we'd like.

Also bump up the default bitcoin rates 