### PR TITLE
[fix] (bitcoin) Fix ideal utxo selection bug

### DIFF
--- a/packages/bitcoin-payments/src/bitcoinish/BitcoinishPayments.ts
+++ b/packages/bitcoin-payments/src/bitcoinish/BitcoinishPayments.ts
@@ -327,7 +327,7 @@ export abstract class BitcoinishPayments<Config extends BaseConfig> extends Bitc
     } else { // Sending amount case
       // First try to find a single input that covers output without creating change
       const idealSolutionFeeSat = this.estimateTxFee(feeRate, 1, 0, outputAddresses)
-      const idealSolutionMinSat = outputTotal + (recipientPaysFee ? idealSolutionFeeSat : 0)
+      const idealSolutionMinSat = outputTotal + (recipientPaysFee ? 0 : idealSolutionFeeSat)
       const idealSolutionMaxSat = idealSolutionMinSat + this.dustThreshold
       for (const utxo of utxos) {
         if (utxo.satoshis >= idealSolutionMinSat && utxo.satoshis <= idealSolutionMaxSat) {

--- a/packages/bitcoin-payments/test/e2e.mainnet.test.ts
+++ b/packages/bitcoin-payments/test/e2e.mainnet.test.ts
@@ -167,6 +167,34 @@ describeAll('e2e mainnet', () => {
 
   })
 
+  it('creates ideal solution transaction with fee paid by sender', async () => {
+    const targetUtxo = address0utxos[0]
+    const fee = '0.00002'
+    const amount = new BigNumber(targetUtxo.value).minus(fee).toString()
+    const tx = await payments.createTransaction(0, 3, amount, {
+      feeRate: fee,
+      feeRateType: FeeRateType.Main,
+      recipientPaysFee: false,
+    })
+    expect(tx.fee).toBe(fee)
+    expect(tx.amount).toBe(amount)
+    expectEqualOmit(tx.inputUtxos, [targetUtxo], omitUtxoFieldEquality)
+  })
+
+  it('creates ideal solution transaction with fee paid by recipient', async () => {
+    const targetUtxo = address0utxos[0]
+    const fee = '0.00002'
+    const amount = targetUtxo.value
+    const tx = await payments.createTransaction(0, 3, amount, {
+      feeRate: fee,
+      feeRateType: FeeRateType.Main,
+      recipientPaysFee: false,
+    })
+    expect(tx.fee).toBe(fee)
+    expect(tx.amount).toBe(new BigNumber(amount).minus(fee).toString())
+    expectEqualOmit(tx.inputUtxos, [targetUtxo], omitUtxoFieldEquality)
+  })
+
   it('creates transaction with fixed fee paid by sender', async () => {
     const fee = '0.00002'
     const amount = '0.00005'


### PR DESCRIPTION
In some cases where a single utxo can be selected to cover the entire transaction the incorrect minimum was being used. This resulted in the fee being subtracted from the output of a transaction without `recipientPaysFee` enabled.