### PR TITLE
[fix] (bitcoin) Only consider payment txs with useAllUtxos as sweeps

### DIFF
--- a/packages/bitcoin-payments/src/bitcoinish/BitcoinishPayments.ts
+++ b/packages/bitcoin-payments/src/bitcoinish/BitcoinishPayments.ts
@@ -424,7 +424,7 @@ export abstract class BitcoinishPayments<Config extends BaseConfig> extends Bitc
       useUnconfirmedUtxos,
       recipientPaysFee,
     )
-    const isSweep = desiredOutputTotal === inputTotal
+    const isSweep = useAllUtxos && desiredOutputTotal === inputTotal
 
     let externalOutputTotal = desiredOutputTotal
     if (recipientPaysFee || isSweep) {

--- a/packages/bitcoin-payments/src/bitcoinish/BitcoinishPayments.ts
+++ b/packages/bitcoin-payments/src/bitcoinish/BitcoinishPayments.ts
@@ -354,7 +354,7 @@ export abstract class BitcoinishPayments<Config extends BaseConfig> extends Bitc
         selectedTotalSat += utxo.satoshis
         const targetChangeOutputCount = this.determineTargetChangeOutputCount(unusedUtxos.length, selectedUtxos.length)
         feeSat = this.estimateTxFee(feeRate, selectedUtxos.length, targetChangeOutputCount, outputAddresses)
-        const neededSat = outputTotal + (recipientPaysFee ? feeSat : 0)
+        const neededSat = outputTotal + (recipientPaysFee ? 0 : feeSat)
         if (selectedTotalSat >= neededSat) {
           break
         }

--- a/packages/bitcoin-payments/test/e2e.mainnet.test.ts
+++ b/packages/bitcoin-payments/test/e2e.mainnet.test.ts
@@ -167,6 +167,16 @@ describeAll('e2e mainnet', () => {
 
   })
 
+  it('cannot create transaction with fee paid by sender when amount equals balance', async () => {
+    const fee = '0.00002'
+    const amount = address0balance
+    await expect(payments.createTransaction(0, 3, amount, {
+      feeRate: fee,
+      feeRateType: FeeRateType.Main,
+      recipientPaysFee: false,
+    })).rejects.toThrow('You do not have enough UTXOs')
+  })
+
   it('creates ideal solution transaction with fee paid by sender', async () => {
     const targetUtxo = address0utxos[0]
     const fee = '0.00002'
@@ -188,7 +198,7 @@ describeAll('e2e mainnet', () => {
     const tx = await payments.createTransaction(0, 3, amount, {
       feeRate: fee,
       feeRateType: FeeRateType.Main,
-      recipientPaysFee: false,
+      recipientPaysFee: true,
     })
     expect(tx.fee).toBe(fee)
     expect(tx.amount).toBe(new BigNumber(amount).minus(fee).toString())


### PR DESCRIPTION
This caused some ideal solution transactions to be considered as sweeps and their fee deducted from the output when they shouldn't be.

Also, fix the neededSat value in the non-ideal solution case. Forgot that in the previous PR