### PR TITLE
[fix] (bitcoinish) Enforce dust threshold on external outputs

### DIFF
--- a/packages/bitcoin-payments/src/bitcoinish/BitcoinishPayments.ts
+++ b/packages/bitcoin-payments/src/bitcoinish/BitcoinishPayments.ts
@@ -519,11 +519,11 @@ export abstract class BitcoinishPayments<Config extends BaseConfig> extends Bitc
         throw new Error(`Invalid ${this.coinSymbol} address ${address} provided for output ${i}`)
       }
       const satoshis = this.toBaseDenominationNumber(value)
-      if (isNaN(satoshis)) {
-        throw new Error(`Invalid ${this.coinSymbol} value (${value}) provided to createMultiOutputTransaction output ${i} (${address})`)
+      if (isNaN(satoshis) || satoshis <= 0) {
+        throw new Error(`Invalid ${this.coinSymbol} value (${value}) provided for output ${i} (${address}) - not a positive, non-zero number`)
       }
-      if (satoshis <= 0) {
-        throw new Error(`Invalid ${this.coinSymbol} positive value (${value}) provided for output ${i} (${address})`)
+      if (satoshis <= this.dustThreshold) {
+        throw new Error(`Invalid ${this.coinSymbol} value (${value}) provided for output ${i} (${address}) - below dust threshold (${this.dustThreshold} sat)`)
       }
       tbc.externalOutputs.push({ address, satoshis })
       tbc.externalOutputAddresses.push(address)

--- a/packages/bitcoin-payments/test/e2e.mainnet.test.ts
+++ b/packages/bitcoin-payments/test/e2e.mainnet.test.ts
@@ -177,6 +177,14 @@ describeAll('e2e mainnet', () => {
     })).rejects.toThrow('You do not have enough UTXOs')
   })
 
+  it('cannot create transaction output below dust threshold', async () => {
+    const fee = '0.00002'
+    await expect(payments.createTransaction(0, 3, '0.00000001', {
+      feeRate: fee,
+      feeRateType: FeeRateType.Main,
+    })).rejects.toThrow('below dust threshold')
+  })
+
   it('creates ideal solution transaction with fee paid by sender', async () => {
     const targetUtxo = address0utxos[0]
     const fee = '0.00002'


### PR DESCRIPTION
I happened to notice the network imposed minimum output amount wasn't being enforced when building the payment tx