### PR TITLE
[feat] (ripple) Deprecate initAccounts for createServiceTransaction

### DIFF
--- a/packages/payments-common/src/BasePayments.ts
+++ b/packages/payments-common/src/BasePayments.ts
@@ -164,7 +164,7 @@ export interface BasePayments<
   ): Promise<UnsignedTransaction>
 
   /**
-   * Creates a new payment transaction sending the entire balance of payport `from` to payport `to`.
+   * Creates a new service transaction (ie contract deploy, change settings)
    */
   createServiceTransaction<O extends CreateTransactionOptions>(
     from?: number | string,


### PR DESCRIPTION
The `initAccounts` method was added as a temporary workaround to get the correct settings configured on the deposit address. Now that we have a "service transaction" concept it can be used instead during an initialization step.