### PR TITLE
[fix] (bitcoinish) Throw on fee estimate failure instead of using default

### DIFF
--- a/packages/bitcoin-cash-payments/src/BaseBitcoinCashPayments.ts
+++ b/packages/bitcoin-cash-payments/src/BaseBitcoinCashPayments.ts
@@ -53,10 +53,7 @@ export abstract class BaseBitcoinCashPayments<Config extends BaseBitcoinCashPaym
     try {
       satPerByte = await new BitcoinCashPaymentsUtils().getBlockBookFeeEstimate(feeLevel, this.networkType)
     } catch (e) {
-      satPerByte = DEFAULT_SAT_PER_BYTE_LEVELS[feeLevel]
-      this.logger.warn(
-        `Failed to get bitcoin cash ${this.networkType} fee estimate, using hardcoded default of ${feeLevel} sat/byte -- ${e.message}`
-      )
+      throw new Error(`Failed to get bitcoin cash ${this.networkType} fee estimate from blockcypher -- ${e.message}`)
     }
     return {
       feeRate: satPerByte.toString(),

--- a/packages/bitcoin-payments/src/BaseBitcoinPayments.ts
+++ b/packages/bitcoin-payments/src/BaseBitcoinPayments.ts
@@ -54,10 +54,7 @@ export abstract class BaseBitcoinPayments<Config extends BaseBitcoinPaymentsConf
     try {
       satPerByte = await getBlockcypherFeeEstimate(feeLevel, this.networkType, this.blockcypherToken)
     } catch (e) {
-      satPerByte = DEFAULT_SAT_PER_BYTE_LEVELS[feeLevel]
-      this.logger.warn(
-        `Failed to get bitcoin ${this.networkType} fee estimate, using hardcoded default of ${satPerByte} sat/byte -- ${e.message}`
-      )
+      throw new Error(`Failed to get bitcoin ${this.networkType} fee estimate from blockcypher -- ${e.message}`)
     }
     return {
       feeRate: satPerByte.toString(),

--- a/packages/bitcoin-payments/test/e2e.mainnet.test.ts
+++ b/packages/bitcoin-payments/test/e2e.mainnet.test.ts
@@ -155,14 +155,13 @@ describeAll('e2e mainnet', () => {
       expect(Number.parseFloat(estimate.feeRate)).toBeGreaterThan(1)
     })
 
-    it('falls back to hardcoded with invalid token', async () => {
+    it('throws on invalid token', async () => {
       const paymentsWithToken = new HdBitcoinPayments({
         ...paymentsConfig,
         blockcypherToken: 'invalid',
       })
-      const estimate = await paymentsWithToken.getFeeRateRecommendation(FeeLevel.High)
-      expect(estimate.feeRateType).toBe(FeeRateType.BasePerWeight)
-      expect(Number.parseFloat(estimate.feeRate)).toBe(DEFAULT_SAT_PER_BYTE_LEVELS[FeeLevel.High])
+      await expect(() => paymentsWithToken.getFeeRateRecommendation(FeeLevel.High))
+        .rejects.toThrow('Failed to get bitcoin mainnet fee estimate from blockcypher')
     })
 
   })

--- a/packages/litecoin-payments/src/BaseLitecoinPayments.ts
+++ b/packages/litecoin-payments/src/BaseLitecoinPayments.ts
@@ -57,10 +57,7 @@ extends BitcoinishPayments<Config> {
     try {
       satPerByte = await getBlockcypherFeeEstimate(feeLevel, this.networkType, this.blockcypherToken)
     } catch (e) {
-      satPerByte = DEFAULT_SAT_PER_BYTE_LEVELS[feeLevel]
-      this.logger.warn(
-        `Failed to get litecoin ${this.networkType} fee estimate, using hardcoded default of ${satPerByte} sat/byte -- ${e.message}`
-      )
+      throw new Error(`Failed to get litecoin ${this.networkType} fee estimate from blockcypher -- ${e.message}`)
     }
     return {
       feeRate: satPerByte.toString(),

--- a/packages/litecoin-payments/test/e2e.mainnet.test.ts
+++ b/packages/litecoin-payments/test/e2e.mainnet.test.ts
@@ -153,14 +153,13 @@ describeAll('e2e mainnet', () => {
       expect(Number.parseFloat(estimate.feeRate)).toBeGreaterThan(1)
     })
 
-    it('falls back to hardcoded with invalid token', async () => {
+    it('throws on invalid token', async () => {
       const paymentsWithToken = new HdLitecoinPayments({
         ...paymentsConfig,
         blockcypherToken: 'invalid',
       })
-      const estimate = await paymentsWithToken.getFeeRateRecommendation(FeeLevel.High)
-      expect(estimate.feeRateType).toBe(FeeRateType.BasePerWeight)
-      expect(Number.parseFloat(estimate.feeRate)).toBe(DEFAULT_SAT_PER_BYTE_LEVELS[FeeLevel.High])
+      await expect(() => paymentsWithToken.getFeeRateRecommendation(FeeLevel.High))
+        .rejects.toThrow('Failed to get litecoin mainnet fee estimate from blockcypher')
     })
 
   })


### PR DESCRIPTION
Hardcoded default fee rates lead to stuck or overpaid transactions. Throw when blockcypher fails so it can be retried later