### PR TITLE
Fix sweeping when dust utxos are filtered

### DIFF
--- a/packages/bitcoin-payments/test/e2e.mainnet.test.ts
+++ b/packages/bitcoin-payments/test/e2e.mainnet.test.ts
@@ -41,7 +41,7 @@ function assertTxInfo(actual: BitcoinTransactionInfo, expected: BitcoinTransacti
       ...actual.data,
       vout: (actual.data as any).vout.map((o: any) => omit(o, ['spent'])),
     },
-  }, expected, ['data.confirmations', 'confirmations'])
+  }, expected, ['data.confirmations', 'confirmations', 'currentBlockNumber'])
 }
 
 const describeAll = !secretXprv ? describe.skip : describe


### PR DESCRIPTION
When attempting to sweep an address with dust input utxos, the external output amount total doesn't match up with the filtered input total resulting in incorrect output amounts and an error. This must be merged before 3.0.0 goes live

TODO: add test