### PR TITLE
Remove tx fromAddress validation incompatible with multisig

### DIFF
--- a/packages/bitcoin-payments/src/BaseBitcoinPayments.ts
+++ b/packages/bitcoin-payments/src/BaseBitcoinPayments.ts
@@ -223,11 +223,6 @@ export abstract class BaseBitcoinPayments<Config extends BaseBitcoinPaymentsConf
       )
     }
 
-    const expectedFromAddress = this.getAddress(tx.fromIndex)
-    if (tx.fromAddress !== expectedFromAddress) {
-      throw new Error(`Invalid tx: fromAddress (${tx.fromAddress}) doesn't match address at fromIndex ${tx.fromIndex} (${expectedFromAddress})`)
-    }
-
     let inputTotal = new BigNumber(0)
 
     // Safe to assume inputs are consistently ordered


### PR DESCRIPTION
The address at `fromIndex` doesn't match `fromAddress` for all multisig transactions or singlesig transactions that are using a different address type. Additionally, this function is meant to be validating that the PSBT is consistent with the tx object, not that the tx is consistent with itself. For those reasons it makes the most sense to just remove this altogether