### PR TITLE
Fix loose change allocation when recipient pays fee

### DIFF
--- a/common/testUtils.ts
+++ b/common/testUtils.ts
@@ -26,15 +26,15 @@ const logDir = path.resolve(__dirname, '../logs')
 
 export class TestLogger implements Logger {
 
-  logFile: any
+  logFileDescriptor: number
 
   constructor(public packageName: string) {
     if (!fs.existsSync(logDir)) {
       fs.mkdirSync(logDir, { recursive: true })
     }
 
-    this.logFile = fs.createWriteStream(
-      path.resolve(logDir, `test.${packageName}.log`), { flags: 'w' }
+    this.logFileDescriptor = fs.openSync(
+      path.resolve(logDir, `test.${packageName}.log`), 'w'
     )
   }
 
@@ -44,7 +44,7 @@ export class TestLogger implements Logger {
       if (process.env.VERBOSE || level === 'ERROR' || level === 'WARN' || level === 'INFO') {
         process.stderr.write(message)
       }
-      this.logFile.write(message)
+      fs.writeSync(this.logFileDescriptor, message)
     }
   }
 

--- a/packages/bitcoin-payments/src/bitcoinish/BitcoinishPayments.ts
+++ b/packages/bitcoin-payments/src/bitcoinish/BitcoinishPayments.ts
@@ -296,16 +296,16 @@ export abstract class BitcoinishPayments<Config extends BaseConfig> extends Bitc
 
   /** Adjust all the output amounts such that externalOutputTotal equals newOutputTotal (+/- a few satoshis less) */
   private adjustOutputAmounts(tbc: BitcoinishTxBuildContext, newOutputTotal: number, description: string): void {
-    // positive change -> increase outputs
-    // negative change -> decrease outputs
-    let totalChange = newOutputTotal - tbc.externalOutputTotal
+    // positive adjustment -> increase outputs
+    // negative adjustment -> decrease outputs
+    let totalAdjustment = newOutputTotal - tbc.externalOutputTotal
     // Share the adjustment across all outputs. This may be an extra 1 less sat per output, negligible
     const outputCount = tbc.externalOutputs.length
-    const amountChangePerOutput = Math.floor(totalChange / outputCount)
-    totalChange = amountChangePerOutput * outputCount
+    const amountChangePerOutput = Math.floor(totalAdjustment / outputCount)
+    totalAdjustment = amountChangePerOutput * outputCount
     this.logger.log(
-      `${this.coinSymbol} buildPaymentTx - Adjusting external outputs by ${totalChange} sat from ${outputCount} `
-      + `outputs (${amountChangePerOutput} sat each) for ${description}`
+      `${this.coinSymbol} buildPaymentTx - Adjusting external output total (${tbc.externalOutputTotal} sat) by ${totalAdjustment} sat `
+      + `from ${outputCount} outputs (${amountChangePerOutput} sat each) for ${description}`
     )
     for (let i = 0; i < outputCount; i++) {
       const externalOutput = tbc.externalOutputs[i]
@@ -324,23 +324,23 @@ export abstract class BitcoinishPayments<Config extends BaseConfig> extends Bitc
       }
       externalOutput.satoshis += amountChangePerOutput
     }
-    tbc.externalOutputTotal += totalChange
+    tbc.externalOutputTotal += totalAdjustment
   }
 
-  private adjustTxFee(tbc: BitcoinishTxBuildContext, newFeeSat: number): void {
+  private adjustTxFee(tbc: BitcoinishTxBuildContext, newFeeSat: number, description: string): void {
     let feeSatAdjustment = newFeeSat - tbc.feeSat
     if (!tbc.recipientPaysFee && !tbc.isSweep) {
-      this.applyFeeAdjustment(tbc, feeSatAdjustment)
+      this.applyFeeAdjustment(tbc, feeSatAdjustment, description)
       return
     }
-    this.adjustOutputAmounts(tbc, tbc.externalOutputTotal - feeSatAdjustment, 'fee adjustment')
-    this.applyFeeAdjustment(tbc, feeSatAdjustment)
+    this.adjustOutputAmounts(tbc, tbc.externalOutputTotal - feeSatAdjustment, description)
+    this.applyFeeAdjustment(tbc, feeSatAdjustment, description)
   }
 
-  private applyFeeAdjustment(tbc: BitcoinishTxBuildContext, feeSatAdjustment: number): void {
+  private applyFeeAdjustment(tbc: BitcoinishTxBuildContext, feeSatAdjustment: number, description: string): void {
     const feeBefore = tbc.feeSat
     tbc.feeSat += feeSatAdjustment
-    this.logger.debug(`${this.coinSymbol} buildPaymentTx - Adjusted fee from ${feeBefore} sat to ${tbc.feeSat} sat`)
+    this.logger.log(`${this.coinSymbol} buildPaymentTx - Adjusted fee from ${feeBefore} sat to ${tbc.feeSat} sat for ${description}`)
     return
   }
 
@@ -371,7 +371,7 @@ export abstract class BitcoinishPayments<Config extends BaseConfig> extends Bitc
       this.adjustOutputAmounts(tbc, tbc.inputTotal, 'sweep input adjustment')
     }
     const feeSat = this.estimateTxFee(tbc.desiredFeeRate, tbc.inputUtxos.length, 0, tbc.externalOutputAddresses)
-    this.adjustTxFee(tbc, feeSat)
+    this.adjustTxFee(tbc, feeSat, 'sweep fee')
   }
 
   private selectInputUtxosPartial(tbc: BitcoinishTxBuildContext) {
@@ -401,16 +401,10 @@ export abstract class BitcoinishPayments<Config extends BaseConfig> extends Bitc
 
     let selectedTotalSat = tbc.inputUtxos.reduce((total, { satoshis }) => total.plus(satoshis || 0), new BigNumber(0))
 
-    const feeSat = this.estimateTxFee(
-      tbc.desiredFeeRate, // base per weight
-      tbc.inputUtxos.length,
-      targetChangeOutputCount,
-      tbc.externalOutputAddresses,
-    )
-    const neededSat = tbc.externalOutputTotal + (tbc.recipientPaysFee ? 0 : feeSat)
+    const neededSat = tbc.externalOutputTotal + (tbc.recipientPaysFee ? 0 : idealSolutionFeeSat)
 
     if (selectedTotalSat.gte(neededSat)) {
-      this.adjustTxFee(tbc, idealSolutionFeeSat)
+      this.adjustTxFee(tbc, idealSolutionFeeSat, 'forced inputs ideal solution fee')
       return
     } else {
       this.selectFromAvailableUtxos(tbc, idealSolutionMinSat, idealSolutionMaxSat, idealSolutionFeeSat)
@@ -442,7 +436,7 @@ export abstract class BitcoinishPayments<Config extends BaseConfig> extends Bitc
         )
         tbc.inputUtxos.push(utxo)
         tbc.inputTotal += utxo.satoshis as number
-        this.adjustTxFee(tbc, idealSolutionFeeSat)
+        this.adjustTxFee(tbc, idealSolutionFeeSat, 'ideal solution fee')
         return
       }
     }
@@ -469,7 +463,7 @@ export abstract class BitcoinishPayments<Config extends BaseConfig> extends Bitc
       }
     }
 
-    this.adjustTxFee(tbc, feeSat)
+    this.adjustTxFee(tbc, feeSat, 'selected inputs fee')
   }
 
   private allocateChangeOutputs(tbc: BitcoinishTxBuildContext): void {
@@ -523,7 +517,7 @@ export abstract class BitcoinishPayments<Config extends BaseConfig> extends Bitc
         // Due to dropping change outputs we're now overpaying, reduce fee and reallocate to change
         this.logger.log(`${this.coinSymbol} buildPaymentTx - Reducing overestimated fee from ${tbc.feeSat} sat to ${recalculatedFee} sat`)
         const feeBefore = tbc.feeSat
-        this.adjustTxFee(tbc, recalculatedFee)
+        this.adjustTxFee(tbc, recalculatedFee, 'dropped change outputs recalculated fee')
         const adjustedAmount = feeBefore - tbc.feeSat
         tbc.totalChange += adjustedAmount
         looseChange += adjustedAmount
@@ -555,7 +549,7 @@ export abstract class BitcoinishPayments<Config extends BaseConfig> extends Bitc
           `${this.coinSymbol} buildPaymentTx - Ended up with loose change (${looseChange} sat) exceeding dust threshold, this should never happen!`
         )
       }
-      this.adjustTxFee(tbc, tbc.feeSat + looseChange)
+      this.adjustTxFee(tbc, tbc.feeSat + looseChange, 'loose change allocation')
       tbc.totalChange -= looseChange
     }
   }

--- a/packages/bitcoin-payments/src/bitcoinish/BitcoinishPayments.ts
+++ b/packages/bitcoin-payments/src/bitcoinish/BitcoinishPayments.ts
@@ -530,12 +530,15 @@ export abstract class BitcoinishPayments<Config extends BaseConfig> extends Bitc
     } else if (changeOutputCount > 0 && looseChange > 0) {
       // Enough loose change to reallocate amongst all change outputs
       const extraSatPerChangeOutput = Math.floor(looseChange / changeOutputCount)
-      this.logger.log(`${this.coinSymbol} buildPaymentTx - redistributing looseChange of ${extraSatPerChangeOutput} per change output`)
-      for (let i = 0; i < changeOutputCount; i++) {
-        tbc.changeOutputs[i].satoshis += extraSatPerChangeOutput
+      if (extraSatPerChangeOutput > 0) {
+        this.logger.log(`${this.coinSymbol} buildPaymentTx - redistributing looseChange of ${extraSatPerChangeOutput} sat per change output`)
+        for (let i = 0; i < changeOutputCount; i++) {
+          tbc.changeOutputs[i].satoshis += extraSatPerChangeOutput
+        }
+        looseChange -= extraSatPerChangeOutput * changeOutputCount
       }
-      looseChange -= extraSatPerChangeOutput * changeOutputCount
       if (looseChange > 0) {
+        this.logger.log(`${this.coinSymbol} buildPaymentTx - allocating looseChange of ${looseChange} sat to first change output`)
         // A few satoshis are leftover due to rounding, give it to the first change output
         tbc.changeOutputs[0].satoshis += looseChange
         looseChange = 0

--- a/packages/bitcoin-payments/src/bitcoinish/BitcoinishPayments.ts
+++ b/packages/bitcoin-payments/src/bitcoinish/BitcoinishPayments.ts
@@ -549,7 +549,9 @@ export abstract class BitcoinishPayments<Config extends BaseConfig> extends Bitc
           `${this.coinSymbol} buildPaymentTx - Ended up with loose change (${looseChange} sat) exceeding dust threshold, this should never happen!`
         )
       }
-      this.adjustTxFee(tbc, tbc.feeSat + looseChange, 'loose change allocation')
+      // Don't adjust external output amounts here like other fee adjustments because loose change has already been
+      // deducted from the outputs
+      this.applyFeeAdjustment(tbc, looseChange, 'loose change allocation')
       tbc.totalChange -= looseChange
     }
   }


### PR DESCRIPTION
This is a hotfix for a production bug that affects transactions where the amount of change is not evenly divisible across the multiple change outputs ("loose change") and gets mistakenly deducted from the output twice. This in and of itself is not particularly concerning because it's just a negligible rounding error. However the new signing validation logic complains and refuses to sign transactions when a few satoshis are misallocated resulting in stuck production transactions.

The few satoshis of leftover change that can't be evenly allocated used to just be added onto the fee. However when recipient pays fee is enabled this would also deduct the output amount by that amount. This results in an output amount that's a few satoshis lower than it should be, and a total reported fee that's a few satoshis lower than it actually is.

This PR fixes the issue by not deducting loose change from the output amount. It also does the more logical thing and includes that loose change in the first change output (if available) instead of just adding it to the fee.