### PR TITLE
[fix] (bitcoinish) Reduce frequency of loose change by deducting from total weight

### DIFF
--- a/packages/bitcoin-payments/src/BaseBitcoinPayments.ts
+++ b/packages/bitcoin-payments/src/BaseBitcoinPayments.ts
@@ -282,7 +282,11 @@ export abstract class BaseBitcoinPayments<Config extends BaseBitcoinPaymentsConf
 
     //// Check totals
 
-    if (!externalOutputTotal.eq(data.externalOutputTotal)) {
+
+    if (data.inputTotal && !inputTotal.eq(data.inputTotal)) {
+      throw new Error(`Invalid tx: data.externalOutputTotal (${data.externalOutputTotal}) doesn't match expected external output total (${externalOutputTotal})`)
+    }
+    if (data.externalOutputTotal && !externalOutputTotal.eq(data.externalOutputTotal)) {
       throw new Error(`Invalid tx: data.externalOutputTotal (${data.externalOutputTotal}) doesn't match expected external output total (${externalOutputTotal})`)
     }
     if (!changeOutputTotal.eq(data.change)) {

--- a/packages/bitcoin-payments/src/bitcoinish/BitcoinishPayments.ts
+++ b/packages/bitcoin-payments/src/bitcoinish/BitcoinishPayments.ts
@@ -36,7 +36,7 @@ import {
   BitcoinishTxBuildContext,
   BitcoinishBuildPaymentTxParams,
 } from './types'
-import { sumUtxoValue, shuffleUtxos, isConfirmedUtxo, sha256FromHex } from './utils'
+import { sumUtxoValue, shuffleUtxos, isConfirmedUtxo, sha256FromHex, sumField } from './utils'
 import { BitcoinishPaymentsUtils } from './BitcoinishPaymentsUtils'
 import BigNumber from 'bignumber.js'
 
@@ -298,14 +298,15 @@ export abstract class BitcoinishPayments<Config extends BaseConfig> extends Bitc
   private adjustOutputAmounts(tbc: BitcoinishTxBuildContext, newOutputTotal: number, description: string): void {
     // positive adjustment -> increase outputs
     // negative adjustment -> decrease outputs
-    let totalAdjustment = newOutputTotal - tbc.externalOutputTotal
+    const totalBefore = tbc.externalOutputTotal
+    let totalAdjustment = newOutputTotal - totalBefore
     // Share the adjustment across all outputs. This may be an extra 1 less sat per output, negligible
     const outputCount = tbc.externalOutputs.length
     const amountChangePerOutput = Math.floor(totalAdjustment / outputCount)
     totalAdjustment = amountChangePerOutput * outputCount
     this.logger.log(
       `${this.coinSymbol} buildPaymentTx - Adjusting external output total (${tbc.externalOutputTotal} sat) by ${totalAdjustment} sat `
-      + `from ${outputCount} outputs (${amountChangePerOutput} sat each) for ${description}`
+      + `across ${outputCount} outputs (${amountChangePerOutput} sat each) for ${description}`
     )
     for (let i = 0; i < outputCount; i++) {
       const externalOutput = tbc.externalOutputs[i]
@@ -325,6 +326,9 @@ export abstract class BitcoinishPayments<Config extends BaseConfig> extends Bitc
       externalOutput.satoshis += amountChangePerOutput
     }
     tbc.externalOutputTotal += totalAdjustment
+    this.logger.log(
+      `${this.coinSymbol} buildPaymentTx - Adjusted external output total from ${totalBefore} sat to ${tbc.externalOutputTotal} sat for ${description}`
+    )
   }
 
   private adjustTxFee(tbc: BitcoinishTxBuildContext, newFeeSat: number, description: string): void {
@@ -368,7 +372,7 @@ export abstract class BitcoinishPayments<Config extends BaseConfig> extends Bitc
     }
     if (tbc.isSweep && tbc.inputTotal !== tbc.externalOutputTotal) {
       // Some dust inputs were filtered
-      this.adjustOutputAmounts(tbc, tbc.inputTotal, 'sweep input adjustment')
+      this.adjustOutputAmounts(tbc, tbc.inputTotal, 'dust inputs filtering')
     }
     const feeSat = this.estimateTxFee(tbc.desiredFeeRate, tbc.inputUtxos.length, 0, tbc.externalOutputAddresses)
     this.adjustTxFee(tbc, feeSat, 'sweep fee')
@@ -479,8 +483,10 @@ export abstract class BitcoinishPayments<Config extends BaseConfig> extends Bitc
       tbc.unusedUtxoCount,
       tbc.inputUtxos.length,
     )
+    // Sort ascending by weight so we can drop small change outputs first and reduce total weight to avoid loose change
     const changeOutputWeights = this.createWeightedChangeOutputs(targetChangeOutputCount, tbc.changeAddress)
-    const totalChangeWeight = changeOutputWeights.reduce((total, { weight }) => total += weight, 0)
+      .sort((a, b) => a.weight - b.weight)
+    let totalChangeWeight = changeOutputWeights.reduce((total, { weight }) => total += weight, 0)
     let totalChangeAllocated = 0 // Total sat of all change outputs we actually include (omitting dust)
     for (let i = 0; i < changeOutputWeights.length; i++) {
       const { address, weight } = changeOutputWeights[i]
@@ -488,9 +494,10 @@ export abstract class BitcoinishPayments<Config extends BaseConfig> extends Bitc
       const changeSat = Math.floor(tbc.totalChange * (weight / totalChangeWeight))
       if (changeSat <= this.dustThreshold || changeSat < this.minChangeSat) {
         this.logger.debug(
-          `${this.coinSymbol} buildPaymentTx - desired change output ${i} is below dust threshold or minChange, ` +
-          'will redistribute to other change outputs or add to fee'
+          `${this.coinSymbol} buildPaymentTx - desired change output ${i} with weight ${weight}/${totalChangeWeight} is below dust threshold or minChange, `
+          + `reducing total weight to ${totalChangeWeight - weight}`
         )
+        totalChangeWeight -= weight
       } else {
         tbc.changeOutputs.push({ address, satoshis: changeSat })
         totalChangeAllocated += changeSat
@@ -531,20 +538,23 @@ export abstract class BitcoinishPayments<Config extends BaseConfig> extends Bitc
       // Enough loose change to reallocate amongst all change outputs
       const extraSatPerChangeOutput = Math.floor(looseChange / changeOutputCount)
       if (extraSatPerChangeOutput > 0) {
-        this.logger.log(`${this.coinSymbol} buildPaymentTx - redistributing looseChange of ${extraSatPerChangeOutput} sat per change output`)
+        this.logger.log(
+          `${this.coinSymbol} buildPaymentTx - allocating ${extraSatPerChangeOutput * changeOutputCount} sat loose change `
+          + `across ${changeOutputCount} change outputs (${extraSatPerChangeOutput} sat each)`
+        )
         for (let i = 0; i < changeOutputCount; i++) {
           tbc.changeOutputs[i].satoshis += extraSatPerChangeOutput
         }
         looseChange -= extraSatPerChangeOutput * changeOutputCount
       }
       if (looseChange > 0) {
-        this.logger.log(`${this.coinSymbol} buildPaymentTx - allocating looseChange of ${looseChange} sat to first change output`)
+        this.logger.log(`${this.coinSymbol} buildPaymentTx - allocating ${looseChange} sat loose change to first change output`)
         // A few satoshis are leftover due to rounding, give it to the first change output
         tbc.changeOutputs[0].satoshis += looseChange
         looseChange = 0
       }
     } else if (changeOutputCount === 0 && looseChange > this.dustThreshold) {
-      this.logger.log(`${this.coinSymbol} buildPaymentTx - allocating looseChange towards single ${looseChange} sat change output`)
+      this.logger.log(`${this.coinSymbol} buildPaymentTx - allocating all loose change towards single ${looseChange} sat change output`)
       tbc.changeOutputs.push({ address: tbc.changeAddress, satoshis: looseChange })
       changeOutputCount += 1
       looseChange = 0
@@ -561,6 +571,25 @@ export abstract class BitcoinishPayments<Config extends BaseConfig> extends Bitc
       // deducted from the outputs
       this.applyFeeAdjustment(tbc, looseChange, 'loose change allocation')
       tbc.totalChange -= looseChange
+    }
+  }
+
+  private validateBuildContext(tbc: BitcoinishTxBuildContext) {
+    const inputSum = sumField(tbc.inputUtxos, 'satoshis')
+    if (!inputSum.eq(tbc.inputTotal)) {
+      throw new Error(`${this.coinSymbol} buildPaymentTx - invalid context: input utxo sum ${inputSum} doesn't equal inputTotal ${tbc.inputTotal}`)
+    }
+    const externalOutputSum = sumField(tbc.externalOutputs, 'satoshis')
+    if (!externalOutputSum.eq(tbc.externalOutputTotal)) {
+      throw new Error(`${this.coinSymbol} buildPaymentTx - invalid context: external output sum ${externalOutputSum} doesn't equal externalOutputTotal ${tbc.externalOutputTotal}`)
+    }
+    const changeOutputSum = sumField(tbc.changeOutputs, 'satoshis')
+    if (!changeOutputSum.eq(tbc.totalChange)) {
+      throw new Error(`${this.coinSymbol} buildPaymentTx - invalid context: change output sum ${changeOutputSum} doesn't equal totalChange ${tbc.totalChange}`)
+    }
+    const actualFee = inputSum.minus(externalOutputSum).minus(changeOutputSum)
+    if (!actualFee.eq(tbc.feeSat)) {
+      throw new Error(`${this.coinSymbol} buildPaymentTx - invalid context: inputs minus outputs sum ${actualFee} doesn't equal feeSat ${tbc.feeSat}`)
     }
   }
 
@@ -588,10 +617,10 @@ export abstract class BitcoinishPayments<Config extends BaseConfig> extends Bitc
       totalChange: 0,
       changeOutputs: [],
       unusedUtxoCount: params.unusedUtxos.length,
-      enforcedUtxos: this.processUtxos(params.enforcedUtxos, params.useUnconfirmedUtxos),
-      unusedUtxos: this.processUtxos(params.unusedUtxos, params.useUnconfirmedUtxos)
+      enforcedUtxos: this.prepareUtxos(params.enforcedUtxos, params.useUnconfirmedUtxos),
+      unusedUtxos: this.prepareUtxos(params.unusedUtxos, params.useUnconfirmedUtxos)
         .filter((utxo) => {
-          if (utxo.satoshis as number > utxoSpendCost) {
+          if (utxo.satoshis > utxoSpendCost) {
             return true
           }
           this.logger.log(`${this.coinSymbol} buildPaymentTx - Ignoring dust utxo (${utxoSpendCost} sat or lower) ${utxo.txid}:${utxo.vout}`)
@@ -632,11 +661,14 @@ export abstract class BitcoinishPayments<Config extends BaseConfig> extends Bitc
     this.allocateChangeOutputs(tbc)
     this.logger.debug(`${this.coinSymbol} buildPaymentTx - context after allocating change outputs`, tbc)
 
+    this.validateBuildContext(tbc)
+
     const externalOutputsResult = this.convertOutputsToExternalFormat(tbc.externalOutputs)
     const changeOutputsResult = this.convertOutputsToExternalFormat(tbc.changeOutputs)
     const outputsResult = [...externalOutputsResult, ...changeOutputsResult]
     return {
       inputs: tbc.inputUtxos,
+      inputTotal: this.toMainDenominationString(tbc.inputTotal),
       outputs: outputsResult,
       fee: this.toMainDenominationString(tbc.feeSat),
       change: this.toMainDenominationString(tbc.totalChange),
@@ -867,7 +899,7 @@ export abstract class BitcoinishPayments<Config extends BaseConfig> extends Bitc
     }
   }
 
-  private processUtxos(utxos: UtxoInfo[], useUnconfirmedUtxos: boolean): UtxoInfo[] {
+  private prepareUtxos(utxos: UtxoInfo[], useUnconfirmedUtxos: boolean): Array<UtxoInfo & { satoshis: number }> {
     return utxos.map((utxo) => {
       return {
         ...utxo,

--- a/packages/bitcoin-payments/src/bitcoinish/types.ts
+++ b/packages/bitcoin-payments/src/bitcoinish/types.ts
@@ -83,9 +83,11 @@ export const BitcoinishPaymentTx = requiredOptionalCodec(
     changeAddress: nullable(t.string),
   },
   {
+    // Total value of input utxos in main denom
+    inputTotal: t.string,
     // Outputs specified by transaction creator
     externalOutputs: t.array(BitcoinishTxOutput),
-    // Total of external outputs in main denom
+    // Total value of external outputs in main denom
     externalOutputTotal: t.string,
     // Outputs returning to transaction creator
     changeOutputs: t.array(BitcoinishTxOutput),

--- a/packages/bitcoin-payments/src/bitcoinish/utils.ts
+++ b/packages/bitcoin-payments/src/bitcoinish/utils.ts
@@ -63,12 +63,17 @@ export function retryIfDisconnected<T>(fn: () => Promise<T>, api: BlockbookBitco
   )
 }
 
+/** returns the sum of a particular field in an array of items */
+export function sumField<T extends { [key: string]: any }>(items: T[], field: keyof T): BigNumber {
+  return items.reduce((total, item) => total.plus(item[field]), toBigNumber(0))
+}
+
 /**
  * Sum the utxos values (main denomination)
  */
 export function sumUtxoValue(utxos: UtxoInfo[], includeUnconfirmed?: boolean): BigNumber {
   const filtered = includeUnconfirmed ? utxos : utxos.filter(isConfirmedUtxo)
-  return filtered.reduce((total, { value }) => total.plus(value), toBigNumber(0))
+  return sumField(filtered, 'value')
 }
 
 /**

--- a/packages/bitcoin-payments/test/HdBitcoinPayments.test.ts
+++ b/packages/bitcoin-payments/test/HdBitcoinPayments.test.ts
@@ -190,7 +190,7 @@ describe('HdBitcoinPayments', () => {
     it('loose change below dust threshold gets added to first change output', async () => {
       // This test is designed to have 3 change outputs and 1 satoshi loose change that gets allocated
       // to the first change output
-      const unusedUtxos = makeUtxos(['1', '1.00000001'], ['10'])
+      const unusedUtxos = makeUtxos(['1', '1.00000001'])
       const amount = '1.93'
       const paymentTx = await payments.buildPaymentTx({
         enforcedUtxos: [],

--- a/packages/bitcoin-payments/test/HdBitcoinPayments.test.ts
+++ b/packages/bitcoin-payments/test/HdBitcoinPayments.test.ts
@@ -259,6 +259,55 @@ describe('HdBitcoinPayments', () => {
       expect(paymentTx.changeAddress).toBe(null)
       expect(paymentTx.fee).toBe(toBigNumber(feeMain).plus(1e-8).toString())
     })
+    it('recalculated dynamic fee doesnt create loose change when recipient pays fee', async () => {
+      const unusedUtxos = makeUtxos(['1', '1.00000001'])
+      const amount = '1.93'
+      const paymentTx = await payments.buildPaymentTx({
+        enforcedUtxos: [],
+        unusedUtxos,
+        desiredOutputs: [{ address: EXTERNAL_ADDRESS, value: amount }],
+        changeAddress,
+        desiredFeeRate: {
+          feeRate: '100',
+          // Important: Must use sat/byte because so recalculated fee is different after change outputs are dropped
+          feeRateType: FeeRateType.BasePerWeight,
+        },
+        useAllUtxos: false,
+        useUnconfirmedUtxos: false,
+        recipientPaysFee: true,
+      })
+      expectUtxosEqual(paymentTx.inputs, unusedUtxos.slice(0, 2))
+      const expectedOutputAmount = toBigNumber(amount).minus(paymentTx.fee).toString()
+      const expectedExternalOutputs = [{
+        address: EXTERNAL_ADDRESS,
+        value: expectedOutputAmount,
+      }]
+      const expectedChangeOutputs = [
+        {
+          address: changeAddress,
+          value: '0.01000001',
+        },
+        {
+          address: changeAddress,
+          value: '0.02',
+        },
+        {
+          address: changeAddress,
+          value: '0.04',
+        },
+      ]
+      expect(paymentTx.outputs).toEqual([...expectedExternalOutputs, ...expectedChangeOutputs])
+      expect(paymentTx.externalOutputs).toEqual(expectedExternalOutputs)
+      expect(paymentTx.changeOutputs).toEqual(expectedChangeOutputs)
+      expect(paymentTx.externalOutputTotal).toBe(expectedOutputAmount)
+      expect(paymentTx.change).toBe('0.07000001')
+      expect(paymentTx.changeAddress).toBe(null)
+      const expectedFee = toBigNumber(paymentTx.inputTotal)
+        .minus(paymentTx.externalOutputTotal)
+        .minus(paymentTx.change)
+        .toString()
+      expect(paymentTx.fee).toBe(expectedFee)
+    })
   })
 
   for (let k in accountsByAddressType) {


### PR DESCRIPTION
Also add some extra logging and validation to help catch any tx building bugs.

Also includes important fix for loose change allocation after dynamic fee is recalculated when change outputs are dropped. There was an incorrect assumption that a fee reduction means more loose change to allocate. However that is only the case when the recipient isn't paying for the fee. When they are their output total increases and the total/loose change should remain unchanged.