### PR TITLE
Add retries for common request errors

### DIFF
--- a/packages/bitcoin-payments/src/bitcoinish/utils.ts
+++ b/packages/bitcoin-payments/src/bitcoinish/utils.ts
@@ -40,7 +40,9 @@ export function resolveServer(server: BlockbookConnectedConfig['server'], networ
   }
 }
 
-const RETRYABLE_ERRORS = ['timeout', 'disconnected', 'time-out', 'StatusCodeError: 522', 'StatusCodeError: 504', 'ENOTFOUND']
+const RETRYABLE_ERRORS = [
+  'timeout', 'disconnected', 'time-out', 'StatusCodeError: 522', 'StatusCodeError: 504', 'ENOTFOUND', 'ESOCKETTIMEDOUT', 'ETIMEDOUT',
+]
 const MAX_RETRIES = 2
 
 export function retryIfDisconnected<T>(fn: () => Promise<T>, api: BlockbookBitcoin, logger: Logger): Promise<T> {

--- a/packages/ethereum-payments/package-lock.json
+++ b/packages/ethereum-payments/package-lock.json
@@ -3515,6 +3515,11 @@
         "once": "^1.4.0"
       }
     },
+    "err-code": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/err-code/-/err-code-1.1.2.tgz",
+      "integrity": "sha1-BuARbTAo9q70gGhJ6w6mp0iuaWA="
+    },
     "error-ex": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
@@ -22798,6 +22803,15 @@
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "dev": true
     },
+    "promise-retry": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-1.1.1.tgz",
+      "integrity": "sha1-ZznpaOMFHaIM5kl/srUPaRHfPW0=",
+      "requires": {
+        "err-code": "^1.0.0",
+        "retry": "^0.10.0"
+      }
+    },
     "prompts": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.3.2.tgz",
@@ -23161,6 +23175,11 @@
       "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
       "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
       "dev": true
+    },
+    "retry": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.10.1.tgz",
+      "integrity": "sha1-52OI0heZLCUnUCQdPTlW/tmNj/Q="
     },
     "rimraf": {
       "version": "2.7.1",

--- a/packages/ethereum-payments/package.json
+++ b/packages/ethereum-payments/package.json
@@ -86,6 +86,7 @@
     "ethereumjs-util": "^6.2.0",
     "io-ts": "^1.10.4",
     "lodash": "^4.17.15",
+    "promise-retry": "^1.1.1",
     "request-promise-native": "^1.0.8",
     "web3": "^1.2.11",
     "web3-eth-contract": "^1.2.11"

--- a/packages/ethereum-payments/src/erc20/BaseErc20Payments.ts
+++ b/packages/ethereum-payments/src/erc20/BaseErc20Payments.ts
@@ -247,14 +247,14 @@ export abstract class BaseErc20Payments <Config extends BaseErc20PaymentsConfig>
 
   async getTransactionInfo(txid: string): Promise<EthereumTransactionInfo> {
     const minConfirmations = MIN_CONFIRMATIONS
-    const tx = await this.eth.getTransaction(txid)
+    const tx = await this._retryDced(() => this.eth.getTransaction(txid))
 
     if (!tx.input) {
       throw new Error(`Transaction ${txid} has no input for ERC20`)
     }
 
-    const currentBlockNumber = await this.eth.getBlockNumber()
-    let txReceipt: TransactionReceipt | null = await this.eth.getTransactionReceipt(txid)
+    const currentBlockNumber = await this._retryDced(() => this.eth.getBlockNumber())
+    let txReceipt: TransactionReceipt | null = await this._retryDced(() => this.eth.getTransactionReceipt(txid))
 
     let fromAddress = tx.from.toLowerCase()
     let toAddress = ''
@@ -388,7 +388,7 @@ export abstract class BaseErc20Payments <Config extends BaseErc20PaymentsConfig>
       confirmations = currentBlockNumber - tx.blockNumber
       if (confirmations > minConfirmations) {
         isConfirmed = true
-        txBlock = await this.eth.getBlock(tx.blockNumber)
+        txBlock = await this._retryDced(() => this.eth.getBlock(tx.blockNumber!))
         confirmationTimestamp = new Date(txBlock.timestamp)
       }
     }
@@ -437,7 +437,7 @@ export abstract class BaseErc20Payments <Config extends BaseErc20PaymentsConfig>
   }
 
   private async getEthBaseBalance(address: string): Promise<BigNumber> {
-    const balanceBase = await this.eth.getBalance(address)
+    const balanceBase = await this._retryDced(() => this.eth.getBalance(address))
 
     return new BigNumber(balanceBase)
   }

--- a/packages/ethereum-payments/src/utils.ts
+++ b/packages/ethereum-payments/src/utils.ts
@@ -1,16 +1,8 @@
 import { isMatchingError, Logger } from '@faast/ts-common'
 import promiseRetry from 'promise-retry'
 
-/** Converts strings to Error */
-export function toError(e: any): any {
-  if (typeof e === 'string') {
-    return new Error(e)
-  }
-  return e
-}
-
 const RETRYABLE_ERRORS = [
-  'Request failed',
+  'request failed or timed out',
 ]
 const MAX_RETRIES = 2
 
@@ -18,10 +10,9 @@ export function retryIfDisconnected<T>(fn: () => Promise<T>, logger: Logger): Pr
   return promiseRetry(
     (retry, attempt) => {
       return fn().catch(async e => {
-        e = toError(e)
         if (isMatchingError(e, RETRYABLE_ERRORS)) {
           logger.log(
-            `Retryable error during tron-payments call, retrying ${MAX_RETRIES - attempt} more times`,
+            `Retryable error during ethereum-payments call, retrying ${MAX_RETRIES - attempt} more times`,
             e.toString(),
           )
           retry(e)

--- a/packages/tron-payments/package-lock.json
+++ b/packages/tron-payments/package-lock.json
@@ -1596,6 +1596,15 @@
       "integrity": "sha512-IkVfat549ggtkZUthUzEX49562eGikhSYeVGX97SkMFn+sTZrgRewXjQ4tPKFPCykZHkX1Zfd9OoELGqKU2jJA==",
       "dev": true
     },
+    "@types/promise-retry": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@types/promise-retry/-/promise-retry-1.1.3.tgz",
+      "integrity": "sha512-LxIlEpEX6frE3co3vCO2EUJfHIta1IOmhDlcAsR4GMMv9hev1iTI9VwberVGkePJAuLZs5rMucrV8CziCfuJMw==",
+      "dev": true,
+      "requires": {
+        "@types/retry": "*"
+      }
+    },
     "@types/resolve": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-0.0.8.tgz",
@@ -1604,6 +1613,12 @@
       "requires": {
         "@types/node": "*"
       }
+    },
+    "@types/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+      "dev": true
     },
     "@types/stack-utils": {
       "version": "1.0.1",
@@ -2819,6 +2834,11 @@
       "requires": {
         "once": "^1.4.0"
       }
+    },
+    "err-code": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/err-code/-/err-code-1.1.2.tgz",
+      "integrity": "sha1-BuARbTAo9q70gGhJ6w6mp0iuaWA="
     },
     "error-ex": {
       "version": "1.3.2",
@@ -7700,6 +7720,15 @@
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "dev": true
     },
+    "promise-retry": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-1.1.1.tgz",
+      "integrity": "sha1-ZznpaOMFHaIM5kl/srUPaRHfPW0=",
+      "requires": {
+        "err-code": "^1.0.0",
+        "retry": "^0.10.0"
+      }
+    },
     "prompts": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.3.2.tgz",
@@ -7935,6 +7964,11 @@
       "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
       "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
       "dev": true
+    },
+    "retry": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.10.1.tgz",
+      "integrity": "sha1-52OI0heZLCUnUCQdPTlW/tmNj/Q="
     },
     "rimraf": {
       "version": "2.6.2",

--- a/packages/tron-payments/package.json
+++ b/packages/tron-payments/package.json
@@ -55,6 +55,7 @@
     "js-sha3": "^0.8.0",
     "jssha": "^2.3.1",
     "lodash": "^4.17.15",
+    "promise-retry": "^1.1.1",
     "tronweb": "^2.10.1"
   },
   "devDependencies": {
@@ -64,6 +65,7 @@
     "@types/jssha": "^2.0.0",
     "@types/lodash": "^4.14.123",
     "@types/node": "^14.0.24",
+    "@types/promise-retry": "^1.1.3",
     "coveralls": "^3.0.2",
     "jest": "^26.1.0",
     "jest-circus": "^26.1.0",


### PR DESCRIPTION
I'm seeing an increased number of failed requests as of late. Retries should help with this
- Bitcoin: recognize more types of timeout errors
- Ethereum: Add retries on failed requests
- Tron: Add retries on failed requests