### PR TITLE
Assorted eth/erc20 fixes

### DIFF
--- a/packages/ethereum-payments/src/BaseEthereumPayments.ts
+++ b/packages/ethereum-payments/src/BaseEthereumPayments.ts
@@ -1,7 +1,6 @@
 import { BigNumber } from 'bignumber.js'
 import { Transaction as Tx } from 'ethereumjs-tx'
-import Web3 from 'web3'
-import type { TransactionReceipt, TransactionConfig } from 'web3-core'
+import type { TransactionReceipt, Transaction, TransactionConfig } from 'web3-core'
 import { cloneDeep } from 'lodash'
 import {
   BalanceResult,
@@ -229,7 +228,12 @@ export abstract class BaseEthereumPayments<Config extends BaseEthereumPaymentsCo
     // XXX it is suggested to keep 12 confirmations
     // https://ethereum.stackexchange.com/questions/319/what-number-of-confirmations-is-considered-secure-in-ethereum
     const minConfirmations = MIN_CONFIRMATIONS
-    const tx = await this._retryDced(() => this.eth.getTransaction(txid))
+    const tx: Transaction | null = await this._retryDced(() => this.eth.getTransaction(txid))
+
+    if (!tx) {
+      throw new Error(`Transaction ${txid} not found`)
+    }
+
     const currentBlockNumber = await this._retryDced(() => this.eth.getBlockNumber())
     let txInfo: TransactionReceipt | null = await this._retryDced(() => this.eth.getTransactionReceipt(txid))
 

--- a/packages/ethereum-payments/src/BaseEthereumPayments.ts
+++ b/packages/ethereum-payments/src/BaseEthereumPayments.ts
@@ -21,6 +21,7 @@ import {
   AutoFeeLevels,
 } from '@faast/payments-common'
 import { isType, isString, isMatchingError } from '@faast/ts-common'
+import request from 'request-promise-native'
 
 import {
   EthereumTransactionInfo,
@@ -399,6 +400,15 @@ export abstract class BaseEthereumPayments<Config extends BaseEthereumPaymentsCo
     }
 
     try {
+      if (this.config.blockbookNode) {
+        const url = `${this.config.blockbookNode}/api/sendtx/${tx.data.hex}`
+        request
+          .get(url, { json: true })
+          .then((res) => this.logger.log(`Successful secondary broadcast to trezor ethereum ${res.result}`))
+          .catch((e) =>
+            this.logger.log(`Failed secondary broadcast to trezor ethereum ${tx.id}: ${url} - ${e}`),
+          )
+      }
       const txId = await this.sendTransactionWithoutConfirmation(tx.data.hex)
       return {
         id: txId,

--- a/packages/ethereum-payments/src/constants.ts
+++ b/packages/ethereum-payments/src/constants.ts
@@ -24,6 +24,8 @@ export const TOKEN_TRANSFER_COST = '150000'
 /** Multiply all web3 estimateGas calls by this because it's innacurate */
 export const GAS_ESTIMATE_MULTIPLIER = 1.5
 
+export const MIN_SWEEPABLE_WEI = String(21000*10e9) // 21k gas @ 10Gwei: anything below this is dust ($0.2 @ $1200/ETH)
+
 export const GAS_STATION_FEE_SPEED = {
   [FeeLevel.Low]: 'safeLow',
   [FeeLevel.Medium]: 'average',

--- a/packages/ethereum-payments/src/erc20/BaseErc20Payments.ts
+++ b/packages/ethereum-payments/src/erc20/BaseErc20Payments.ts
@@ -42,7 +42,7 @@ export abstract class BaseErc20Payments <Config extends BaseErc20PaymentsConfig>
   }
 
   abstract getAddressSalt(index: number): string
-  abstract async getPayport(index: number): Promise<Payport>
+  abstract getPayport(index: number): Promise<Payport>
 
   private newContract(...args: ConstructorParameters<typeof Contract>) {
     const contract = new Contract(...args)
@@ -67,17 +67,8 @@ export abstract class BaseErc20Payments <Config extends BaseErc20PaymentsConfig>
   }
 
   async isSweepableBalance(balance: string): Promise<boolean> {
-    const feeOption = await this.resolveFeeOption({})
-    const payport = await this.resolvePayport(this.depositKeyIndex)
-
-    const feeWei = new BigNumber(feeOption.feeBase)
-    const balanceWei = await this.eth.getBalance(payport.address)
-
-    if (balanceWei === '0' || balance === '0') {
-      return false
-    }
-
-    return ((new BigNumber(balanceWei)).isGreaterThanOrEqualTo(feeWei))
+    // Any ERC20 balance greater than 0 is sweepable
+    return new BigNumber(balance).isGreaterThan(0)
   }
 
   async createTransaction(

--- a/packages/ethereum-payments/src/types.ts
+++ b/packages/ethereum-payments/src/types.ts
@@ -60,6 +60,7 @@ export const EthereumPaymentsUtilsConfig = extendCodec(
   {
     fullNode: OptionalString,
     parityNode: OptionalString,
+    blockbookNode: OptionalString,
     gasStation: OptionalString,
     symbol: OptionalString,
     name: OptionalString,

--- a/packages/ethereum-payments/test/HdEthereumPayments.test.ts
+++ b/packages/ethereum-payments/test/HdEthereumPayments.test.ts
@@ -48,6 +48,9 @@ import {
 const FROM_ADDRESS = deriveSignatory(INSTANCE_KEYS.xkeys.xprv, 1).address
 const TO_ADDRESS   = hdAccount.rootChild[1].address
 
+// web3 sequential id used by nock
+let id = 1
+
 // methods from base
 describe('HdEthereumPayments', () => {
   let hdEP: any
@@ -227,7 +230,7 @@ describe('HdEthereumPayments', () => {
 
     describe('getBalance', () => {
       test('sends rpc request to node with correct paramaters', async () => {
-        const balanceMocks = getBalanceMocks(1, FROM_ADDRESS, '10000000')
+        const balanceMocks = getBalanceMocks(id++, FROM_ADDRESS, '10000000')
         nockI.post(/.*/, balanceMocks.req).reply(200, balanceMocks.res)
 
         nockG.get('/json/ethgasAPI.json').reply(200, getGasStationResponse())
@@ -250,7 +253,7 @@ describe('HdEthereumPayments', () => {
         const parityMock = getNextNonceMocks(1, FROM_ADDRESS, '0x1b')
         nockP.post(/.*/, parityMock.req).reply(200, parityMock.res)
 
-        const transactionCountMocks = getTransactionCountMocks(2, FROM_ADDRESS, '0x1a')
+        const transactionCountMocks = getTransactionCountMocks(id++, FROM_ADDRESS, '0x1a')
         nockI.post(/.*/, transactionCountMocks.req).reply(200, transactionCountMocks.res)
 
         expect(await hdEP.getNextSequenceNumber(FROM_ADDRESS)).toBe('27')
@@ -263,13 +266,13 @@ describe('HdEthereumPayments', () => {
         const blockId = '0xef95f2f1ed3ca60b048b4bf67cde2195961e0bba6f70bcbea9a2c4e133e34b46'
         const amount = '123450000000000000'
 
-        const transactionByHashMock = getTransactionByHashMocks(3, txId, blockId, 3, FROM_ADDRESS, TO_ADDRESS, amount)
+        const transactionByHashMock = getTransactionByHashMocks(id++, txId, blockId, 3, FROM_ADDRESS, TO_ADDRESS, amount)
         nockI.post(/.*/, transactionByHashMock.req).reply(200, transactionByHashMock.res)
 
-        const blockNumberNock = getBlockNumberMocks(4, '0x3')
+        const blockNumberNock = getBlockNumberMocks(id++, '0x3')
         nockI.post(/.*/, blockNumberNock.req).reply(200, blockNumberNock.res)
 
-        const mockTransactionReceipt = getTransactionReceiptMocks(5, FROM_ADDRESS, TO_ADDRESS, '0x1', '0x3', txId, blockId)
+        const mockTransactionReceipt = getTransactionReceiptMocks(id++, FROM_ADDRESS, TO_ADDRESS, '0x1', '0x3', txId, blockId)
         nockI.post(/.*/, mockTransactionReceipt.req).reply(200, mockTransactionReceipt.res)
 
         const res = await hdEP.getTransactionInfo(txId)
@@ -319,16 +322,16 @@ describe('HdEthereumPayments', () => {
         const blockId = '0xef95f2f1ed3ca60b048b4bf67cde2195961e0bba6f70bcbea9a2c4e133e34b46'
         const amount = '123450000000000000'
 
-        const transactionByHashMock = getTransactionByHashMocks(6, txId, blockId, 3, FROM_ADDRESS, TO_ADDRESS, amount)
+        const transactionByHashMock = getTransactionByHashMocks(id++, txId, blockId, 3, FROM_ADDRESS, TO_ADDRESS, amount)
         nockI.post(/.*/, transactionByHashMock.req).reply(200, transactionByHashMock.res)
 
-        const blockNumberNock = getBlockNumberMocks(7, '0x4')
+        const blockNumberNock = getBlockNumberMocks(id++, '0x4')
         nockI.post(/.*/, blockNumberNock.req).reply(200, blockNumberNock.res)
 
-        const mockTransactionReceipt = getTransactionReceiptMocks(8, FROM_ADDRESS, TO_ADDRESS, '0x1', '0x3', txId, blockId)
+        const mockTransactionReceipt = getTransactionReceiptMocks(id++, FROM_ADDRESS, TO_ADDRESS, '0x1', '0x3', txId, blockId)
         nockI.post(/.*/, mockTransactionReceipt.req).reply(200, mockTransactionReceipt.res)
 
-        const mockBlockByNumber = getBlockByNumberMocks(9, '0x3', blockId, [txId])
+        const mockBlockByNumber = getBlockByNumberMocks(id++, '0x3', blockId, [txId])
         nockI.post(/.*/, mockBlockByNumber.req).reply(200, mockBlockByNumber.res)
 
         const res = await hdEP.getTransactionInfo(txId)
@@ -378,16 +381,16 @@ describe('HdEthereumPayments', () => {
         const blockId = '0xef95f2f1ed3ca60b048b4bf67cde2195961e0bba6f70bcbea9a2c4e133e34b46'
         const amount = '123450000000000000'
 
-        const transactionByHashMock = getTransactionByHashMocks(10, txId, blockId, 3, FROM_ADDRESS, TO_ADDRESS, amount)
+        const transactionByHashMock = getTransactionByHashMocks(id++, txId, blockId, 3, FROM_ADDRESS, TO_ADDRESS, amount)
         nockI.post(/.*/, transactionByHashMock.req).reply(200, transactionByHashMock.res)
 
-        const blockNumberNock = getBlockNumberMocks(11, '0x4')
+        const blockNumberNock = getBlockNumberMocks(id++, '0x4')
         nockI.post(/.*/, blockNumberNock.req).reply(200, blockNumberNock.res)
 
-        const mockTransactionReceipt = getTransactionReceiptMocks(12, FROM_ADDRESS, TO_ADDRESS, '0x0', '0x3', txId, blockId)
+        const mockTransactionReceipt = getTransactionReceiptMocks(id++, FROM_ADDRESS, TO_ADDRESS, '0x0', '0x3', txId, blockId)
         nockI.post(/.*/, mockTransactionReceipt.req).reply(200, mockTransactionReceipt.res)
 
-        const mockBlockByNumber = getBlockByNumberMocks(13, '0x3', blockId, [txId])
+        const mockBlockByNumber = getBlockByNumberMocks(id++, '0x3', blockId, [txId])
         nockI.post(/.*/, mockBlockByNumber.req).reply(200, mockBlockByNumber.res)
 
         const res = await hdEP.getTransactionInfo(txId)
@@ -436,13 +439,13 @@ describe('HdEthereumPayments', () => {
         const txId = '0x9fc76417374aa880d4449a1f7f31ec597f00b1f6f3dd2d66f4c9c6c445836d8b'
         const amount = '123450000000000000'
 
-        const transactionByHashMock = getTransactionByHashMocks(14, txId, null, null, FROM_ADDRESS, TO_ADDRESS, amount)
+        const transactionByHashMock = getTransactionByHashMocks(id++, txId, null, null, FROM_ADDRESS, TO_ADDRESS, amount)
         nockI.post(/.*/, transactionByHashMock.req).reply(200, transactionByHashMock.res)
 
-        const blockNumberNock = getBlockNumberMocks(15, '0x4')
+        const blockNumberNock = getBlockNumberMocks(id++, '0x4')
         nockI.post(/.*/, blockNumberNock.req).reply(200, blockNumberNock.res)
 
-        const mockTransactionReceipt = getTransactionReceiptMocks(16, FROM_ADDRESS, TO_ADDRESS, '0x0', '0x3', txId, null)
+        const mockTransactionReceipt = getTransactionReceiptMocks(id++, FROM_ADDRESS, TO_ADDRESS, '0x0', '0x3', txId, null)
         nockI.post(/.*/, mockTransactionReceipt.req).reply(200, {
           id: 16,
           jsonrpc: '2.0',
@@ -498,20 +501,17 @@ describe('HdEthereumPayments', () => {
         const to = { address: TO_ADDRESS }
         const amountEth = '0.005'
 
-        const estimateGasMocks = getEstimateGasMocks(17, FROM_ADDRESS, TO_ADDRESS, '0xaaaa')
+        const estimateGasMocks = getEstimateGasMocks(id++, FROM_ADDRESS, TO_ADDRESS, '0xaaaa')
         nockI.post(/.*/, estimateGasMocks.req).reply(200, estimateGasMocks.res)
 
         // nock for get balance
-        const balanceMocks = getBalanceMocks(18, FROM_ADDRESS, '9999999999999999999999999999')
+        const balanceMocks = getBalanceMocks(id++, FROM_ADDRESS, '9999999999999999999999999999')
         nockI.post(/.*/, balanceMocks.req).reply(200, balanceMocks.res)
 
         // nock for gas station
         nockG.get('/json/ethgasAPI.json').reply(200, getGasStationResponse())
 
-        const gasPriceMock = getGasPriceMocks(19, '0x1a')
-        nockI.post(/.*/, gasPriceMock.req).reply(200, gasPriceMock.res)
-
-        const transactionCountMocks = getTransactionCountMocks(20, FROM_ADDRESS, '0x1a')
+        const transactionCountMocks = getTransactionCountMocks(id++, FROM_ADDRESS, '0x1a')
         nockI.post(/.*/, transactionCountMocks.req).reply(200, transactionCountMocks.res)
 
         const parityMock = getNextNonceMocks(1, FROM_ADDRESS, '0x1b')
@@ -551,20 +551,16 @@ describe('HdEthereumPayments', () => {
         const to = { address: TO_ADDRESS }
         const amountEth = '50000'
 
-        const estimateGasMocks = getEstimateGasMocks(21, FROM_ADDRESS, TO_ADDRESS, '0xaaaa')
+        const estimateGasMocks = getEstimateGasMocks(id++, FROM_ADDRESS, TO_ADDRESS, '0xaaaa')
         nockI.post(/.*/, estimateGasMocks.req).reply(200, estimateGasMocks.res)
 
         // nock for get balance
-        const balanceMocks = getBalanceMocks(22, FROM_ADDRESS, '49999')
+        const balanceMocks = getBalanceMocks(id++, FROM_ADDRESS, '49999')
         nockI.post(/.*/, balanceMocks.req).reply(200, balanceMocks.res)
-
-        // nock for gas station
-        const gasPriceMock = getGasPriceMocks(23, '0x1a')
-        nockI.post(/.*/, gasPriceMock.req).reply(200, gasPriceMock.res)
 
         nockG.get('/json/ethgasAPI.json').reply(200, getGasStationResponse())
 
-        const transactionCountMocks = getTransactionCountMocks(24, FROM_ADDRESS, '0x1a')
+        const transactionCountMocks = getTransactionCountMocks(id++, FROM_ADDRESS, '0x1a')
         nockI.post(/.*/, transactionCountMocks.req).reply(200, transactionCountMocks.res)
 
         const parityMock = getNextNonceMocks(1, FROM_ADDRESS, '0x1b')
@@ -586,21 +582,17 @@ describe('HdEthereumPayments', () => {
         const to = { address: '0x6295eE1B4F6dD65047762F924Ecd367c17eaBf8f' }
         const balance = '142334532324980082'
 
-        const estimateGasMocks = getEstimateGasMocks(25, FROM_ADDRESS, to.address, '0x52bc')
+        const estimateGasMocks = getEstimateGasMocks(id++, FROM_ADDRESS, to.address, '0x52bc')
         nockI.post(/.*/, estimateGasMocks.req).reply(200, estimateGasMocks.res)
 
         // nock for get balance
-        const balanceMocks = getBalanceMocks(26, FROM_ADDRESS, balance)
+        const balanceMocks = getBalanceMocks(id++, FROM_ADDRESS, balance)
         nockI.post(/.*/, balanceMocks.req).reply(200, balanceMocks.res)
-
-        // nock for gas station
-        const gasPriceMock = getGasPriceMocks(27, '0x1a')
-        nockI.post(/.*/, gasPriceMock.req).reply(200, gasPriceMock.res)
 
         // nock for gas station
         nockG.get('/json/ethgasAPI.json').reply(200, getGasStationResponse())
 
-        const transactionCountMocks = getTransactionCountMocks(28, FROM_ADDRESS, '0x1a')
+        const transactionCountMocks = getTransactionCountMocks(id++, FROM_ADDRESS, '0x1a')
         nockI.post(/.*/, transactionCountMocks.req).reply(200, transactionCountMocks.res)
 
         const parityMock = getNextNonceMocks(1, FROM_ADDRESS, '0x1b')
@@ -649,21 +641,17 @@ describe('HdEthereumPayments', () => {
         const from = 1
         const to = { address: TO_ADDRESS }
 
-        const estimateGasMocks = getEstimateGasMocks(29, FROM_ADDRESS, TO_ADDRESS, '0x52bc')
+        const estimateGasMocks = getEstimateGasMocks(id++, FROM_ADDRESS, TO_ADDRESS, '0x52bc')
         nockI.post(/.*/, estimateGasMocks.req).reply(200, estimateGasMocks.res)
 
         // nock for get balance
-        const balanceMocks = getBalanceMocks(30, FROM_ADDRESS, '999')
+        const balanceMocks = getBalanceMocks(id++, FROM_ADDRESS, '999')
         nockI.post(/.*/, balanceMocks.req).reply(200, balanceMocks.res)
-        //
-        // nock for gas station
-        const gasPriceMock = getGasPriceMocks(31, '0x1a')
-        nockI.post(/.*/, gasPriceMock.req).reply(200, gasPriceMock.res)
 
         // nock for gas station
         nockG.get('/json/ethgasAPI.json').reply(200, getGasStationResponse())
 
-        const transactionCountMocks = getTransactionCountMocks(32, FROM_ADDRESS, '0x1a')
+        const transactionCountMocks = getTransactionCountMocks(id++, FROM_ADDRESS, '0x1a')
         nockI.post(/.*/, transactionCountMocks.req).reply(200, transactionCountMocks.res)
 
         const parityMock = getNextNonceMocks(1, FROM_ADDRESS, '0x1b')
@@ -734,38 +722,29 @@ describe('HdEthereumPayments', () => {
 
     describe('broadcastTransaction', () => {
       test('sends signed transaction', async () => {
-        const txId = '2d57a8e6d02a195d87d948f207d8740dacb4a8f39546754e2c0142c036643355'
+        const txId = '0x3137b3336975aabfcf141469727d8d805f5e6d343de7fcc93e61d8d19d5d238f'
         const rawTx = '0xf86c0185746a528800825208948f0bb36577b19da9826fc726fec2b4943c45e01488069e4a05f56240008029a0961ab2c131cfb09bbb1d71825615d30634889f95b62390473d1691ba419f86f8a0514d1b9d42888a01cb5cfb7aba6623f4caad4b952943f243c644b3e7aaf409b3'
-        const blockId = '0xef95f2f1ed3ca60b048b4bf67cde2195961e0bba6f70bcbea9a2c4e133e34b46'
-
-        const from = 1
-        const to = { address: TO_ADDRESS }
-        const amountEth = '0.576'
 
         const signedTx = {
           id: txId,
           status: 'signed',
           fromAddress: FROM_ADDRESS.toLowerCase(),
-          toAddress: to.address.toLowerCase(),
+          toAddress: TO_ADDRESS.toLowerCase(),
           toExtraId: null,
-          fromIndex: 0,
+          fromIndex: 1,
           toIndex: null,
-          amount: amountEth,
-          fee: '0.0021',
+          amount: '0.576',
+          fee: '0.0063156',
           targetFeeLevel: 'medium',
-          targetFeeRate: '100000000000',
-          targetFeeRateType: 'base/weight',
+          targetFeeRate: '0',
+          targetFeeRateType: 'base',
           sequenceNumber: '27',
           data: { hex: rawTx }
         }
 
         // sends rpc request with transaction and receives id
-        const rawTxMock = getSendRawTransactionMocks(33, rawTx, txId)
+        const rawTxMock = getSendRawTransactionMocks(id++, rawTx, txId)
         nockI.post(/.*/, rawTxMock.req).reply(200, rawTxMock.res)
-
-        // checks tx receipt by id
-        const mockTransactionReceipt = getTransactionReceiptMocks(32, FROM_ADDRESS, TO_ADDRESS, '0x1', '0x3', txId, blockId)
-        nockI.post(/.*/, mockTransactionReceipt.req).reply(200, mockTransactionReceipt.res)
 
         const res = await hdEP.broadcastTransaction(signedTx)
 

--- a/packages/ethereum-payments/test/HdEthereumPayments.test.ts
+++ b/packages/ethereum-payments/test/HdEthereumPayments.test.ts
@@ -238,7 +238,7 @@ describe('HdEthereumPayments', () => {
           confirmedBalance: '0.00000000001',
           unconfirmedBalance: '0',
           spendableBalance: '0.00000000001',
-          sweepable: true,
+          sweepable: false,
           requiresActivation: false,
         })
       })

--- a/packages/ethereum-payments/test/NetworkData.test.ts
+++ b/packages/ethereum-payments/test/NetworkData.test.ts
@@ -14,6 +14,8 @@ import { TestLogger } from '../../../common/testUtils'
 
 const logger = new TestLogger('ethereum-payments.NetworkData')
 
+let id = 1
+
 describe('NetworkData', () => {
   const GAS_STATION_URL = 'https://gasstation.test.url'
   const PARITY_URL = 'https://parity.test.url'
@@ -34,10 +36,10 @@ describe('NetworkData', () => {
 
     nockG.get('/json/ethgasAPI.json').reply(200, getGasStationResponse())
 
-    const transactionCountMocks = getTransactionCountMocks(1, from, '0x1a')
+    const transactionCountMocks = getTransactionCountMocks(id++, from, '0x1a')
     nockI.post(/.*/, transactionCountMocks.req).reply(200, transactionCountMocks.res)
 
-    const estimateGasPriceMock = getEstimateGasMocks(2, from, to, `0x${(21000).toString(16)}`)
+    const estimateGasPriceMock = getEstimateGasMocks(id++, from, to, `0x${(21000).toString(16)}`)
     nockI.post(/.*/, estimateGasPriceMock.req).reply(200, estimateGasPriceMock.res)
 
     const parityMock = getNextNonceMocks(1, from, '0x1b')
@@ -57,10 +59,10 @@ describe('NetworkData', () => {
 
     nockG.get('/json/ethgasAPI.json').reply(200, getGasStationResponse())
 
-    const transactionCountMocks = getTransactionCountMocks(3, from, '0x1a')
+    const transactionCountMocks = getTransactionCountMocks(id++, from, '0x1a')
     nockI.post(/.*/, transactionCountMocks.req).reply(200, transactionCountMocks.res)
 
-    const estimateGasPriceMock = getEstimateGasMocks(4, from, to, `0x${(32001).toString(16)}`)
+    const estimateGasPriceMock = getEstimateGasMocks(id++, from, to, `0x${(32001).toString(16)}`)
     nockI.post(/.*/, estimateGasPriceMock.req).reply(200, estimateGasPriceMock.res)
 
     const parityMock = getNextNonceMocks(1, from, '0x1b')
@@ -81,16 +83,16 @@ describe('NetworkData', () => {
     // fail
     nockG.get('/json/ethgasAPI.json').reply(400)
 
-    let transactionCountMocks = getTransactionCountMocks(5, from, '')
+    let transactionCountMocks = getTransactionCountMocks(id++, from, '')
     nockI.post(/.*/, transactionCountMocks.req).reply(200, transactionCountMocks.res)
 
-    let gasPriceMock = getGasPriceMocks(6, '')
+    let gasPriceMock = getGasPriceMocks(id++, '')
     nockI.post(/.*/, gasPriceMock.req).reply(200, gasPriceMock.res)
 
-    transactionCountMocks = getTransactionCountMocks(7, from, '')
+    transactionCountMocks = getTransactionCountMocks(id++, from, '')
     nockI.post(/.*/, transactionCountMocks.req).reply(200, transactionCountMocks.res)
 
-    let estimateGasPriceMock = getEstimateGasMocks(8, from, to, '')
+    let estimateGasPriceMock = getEstimateGasMocks(id++, from, to, '')
     nockI.post(/.*/, estimateGasPriceMock.req).reply(200, estimateGasPriceMock.res)
 
     const parityMock = getNextNonceMocks(1, from, '')
@@ -112,16 +114,16 @@ describe('NetworkData', () => {
     nockG.get('/json/ethgasAPI.json').reply(200, {
     })
 
-    let transactionCountMocks = getTransactionCountMocks(9, from, '')
+    let transactionCountMocks = getTransactionCountMocks(id++, from, '')
     nockI.post(/.*/, transactionCountMocks.req).reply(400)
 
-    let gasPriceMock = getGasPriceMocks(10, '')
+    let gasPriceMock = getGasPriceMocks(id++, '')
     nockI.post(/.*/, gasPriceMock.req).reply(200, gasPriceMock.res)
 
-    transactionCountMocks = getTransactionCountMocks(11, from, '')
+    transactionCountMocks = getTransactionCountMocks(id++, from, '')
     nockI.post(/.*/, transactionCountMocks.req).reply(200, transactionCountMocks.res)
 
-    let estimateGasPriceMock = getEstimateGasMocks(12, from, to, '')
+    let estimateGasPriceMock = getEstimateGasMocks(id++, from, to, '')
     nockI.post(/.*/, estimateGasPriceMock.req).reply(200, estimateGasPriceMock.res)
 
     const parityMock = getNextNonceMocks(1, from, '0x1b')

--- a/packages/ethereum-payments/test/fixtures/mocks.ts
+++ b/packages/ethereum-payments/test/fixtures/mocks.ts
@@ -3,56 +3,56 @@ interface Mock {
   res: Object
 }
 
-export function getNextNonceMocks (id: number, address: string, nonce: string): Mock {
+export function getNextNonceMocks (id: number | RegExp, address: string, nonce: string): Mock {
   return {
     req: getNextNonceRequest(id, address),
     res: getNextNonceResponse(id, nonce)
   }
 }
 
-export function getBalanceMocks(id: number, address: string, balance: string): Mock {
+export function getBalanceMocks(id: number | RegExp, address: string, balance: string): Mock {
   return {
     req: getBalanceRequest(id, address),
     res: getBalanceResponse(id, balance),
   }
 }
 
-export function getTransactionCountMocks(id: number, address: string, nonce: string): Mock {
+export function getTransactionCountMocks(id: number | RegExp, address: string, nonce: string): Mock {
   return {
     req: getTransactionCountRequest(id, address),
     res: getTransactionCountResponse(id, nonce)
   }
 }
 
-export function getSendRawTransactionMocks(id: number, rawTx: string, txHash: string): Mock {
+export function getSendRawTransactionMocks(id: number | RegExp, rawTx: string, txHash: string): Mock {
   return {
     req: getSendRawTransactionRequest(id, rawTx),
     res: getSendRawTransactionResponse(id, txHash)
   }
 }
 
-export function getTransactionReceiptMocks(id: number, from: string, to: string, status: string, blockNumber: string | null, txHash: string, blockHash: string | null): Mock {
+export function getTransactionReceiptMocks(id: number | RegExp, from: string, to: string, status: string, blockNumber: string | null, txHash: string, blockHash: string | null): Mock {
   return {
     req: getTransactionReceiptRequest(id, txHash),
     res: getTransactionReceiptResponse(id, from, to, status, blockNumber, txHash, blockHash)
   }
 }
 
-export function getTransactionByHashMocks(id: number, txHash: string, blockHash: string | null, blockNumber: number | null, from: string, to: string, value: string): Mock {
+export function getTransactionByHashMocks(id: number | RegExp, txHash: string, blockHash: string | null, blockNumber: number | null, from: string, to: string, value: string): Mock {
   return {
     req: getTransactionByHashRequest(id, txHash),
     res: getTransactionByHashResponse(id, txHash, blockHash, blockNumber, from, to, value)
   }
 }
 
-export function getBlockNumberMocks(id: number, count: string): Mock {
+export function getBlockNumberMocks(id: number | RegExp, count: string): Mock {
   return {
     req: getBlockNumberRequest(id),
     res: getBlockNumberResponse(id, count)
   }
 }
 
-export function getBlockByNumberMocks(id: number, blockNumber: string, blockHash: string, txHashes: [string]): Mock {
+export function getBlockByNumberMocks(id: number | RegExp, blockNumber: string, blockHash: string, txHashes: [string]): Mock {
   return {
     req: getBlockByNumberRequest(id, blockNumber),
     res: getBlockByNumberResponse(id, blockNumber, blockHash, txHashes)
@@ -99,7 +99,7 @@ export function getGasStationResponse(): Object {
   }
 }
 
-export function getGasPriceMocks(id: number, price: string) {
+export function getGasPriceMocks(id: number | RegExp, price: string) {
   return {
     req: {
       jsonrpc: '2.0',
@@ -115,7 +115,7 @@ export function getGasPriceMocks(id: number, price: string) {
   }
 }
 
-export function getEstimateGasMocks(id: number, from: string, to: string, result: string) {
+export function getEstimateGasMocks(id: number | RegExp, from: string, to: string, result: string) {
   return {
     req: {
       jsonrpc:'2.0',
@@ -133,7 +133,7 @@ export function getEstimateGasMocks(id: number, from: string, to: string, result
     }
   }
 }
-function getNextNonceRequest(id: number, address: string): Object {
+function getNextNonceRequest(id: number | RegExp, address: string): Object {
   return {
     jsonrpc: '2.0',
     method:'parity_nextNonce',
@@ -142,7 +142,7 @@ function getNextNonceRequest(id: number, address: string): Object {
   }
 }
 
-function getNextNonceResponse(id: number, nonce: string): Object {
+function getNextNonceResponse(id: number | RegExp, nonce: string): Object {
   return {
     jsonrpc: '2.0',
     id,
@@ -150,7 +150,7 @@ function getNextNonceResponse(id: number, nonce: string): Object {
   }
 }
 
-function getBalanceRequest(id: number, address: string): Object {
+function getBalanceRequest(id: number | RegExp, address: string): Object {
   return {
     jsonrpc:'2.0',
     id,
@@ -159,7 +159,7 @@ function getBalanceRequest(id: number, address: string): Object {
   }
 }
 
-function getBalanceResponse(id: number, balance: string): Object {
+function getBalanceResponse(id: number | RegExp, balance: string): Object {
   return {
     jsonrpc:'2.0',
     id,
@@ -167,7 +167,7 @@ function getBalanceResponse(id: number, balance: string): Object {
   }
 }
 
-function getTransactionCountRequest(id: number, address: string): Object {
+function getTransactionCountRequest(id: number | RegExp, address: string): Object {
   return {
     jsonrpc:'2.0',
     method:'eth_getTransactionCount',
@@ -176,7 +176,7 @@ function getTransactionCountRequest(id: number, address: string): Object {
   }
 }
 
-function getTransactionCountResponse(id: number, nonce: string): Object {
+function getTransactionCountResponse(id: number | RegExp, nonce: string): Object {
   return {
     jsonrpc: '2.0',
     id,
@@ -184,7 +184,7 @@ function getTransactionCountResponse(id: number, nonce: string): Object {
   }
 }
 
-function getSendRawTransactionRequest(id: number, rawTx: string): Object {
+function getSendRawTransactionRequest(id: number | RegExp, rawTx: string): Object {
   return {
     jsonrpc: '2.0',
     method: 'eth_sendRawTransaction',
@@ -193,7 +193,7 @@ function getSendRawTransactionRequest(id: number, rawTx: string): Object {
   }
 }
 
-function getSendRawTransactionResponse(id: number, txHash: string): Object {
+function getSendRawTransactionResponse(id: number | RegExp, txHash: string): Object {
   return {
     jsonrpc: '2.0',
     id,
@@ -201,7 +201,7 @@ function getSendRawTransactionResponse(id: number, txHash: string): Object {
   }
 }
 
-function getTransactionReceiptRequest(id: number, txHash: string): Object {
+function getTransactionReceiptRequest(id: number | RegExp, txHash: string): Object {
   return {
     jsonrpc: '2.0',
     id,
@@ -210,7 +210,7 @@ function getTransactionReceiptRequest(id: number, txHash: string): Object {
   }
 }
 
-function getTransactionReceiptResponse(id: number, from: string, to:string, status: string, blockNumber: string | null, txHash: string, blockHash: string | null): Object {
+function getTransactionReceiptResponse(id: number | RegExp, from: string, to:string, status: string, blockNumber: string | null, txHash: string, blockHash: string | null): Object {
   return {
     jsonrpc: '2.0',
     id,
@@ -230,7 +230,7 @@ function getTransactionReceiptResponse(id: number, from: string, to:string, stat
   }
 }
 
-function getTransactionByHashRequest(id: number, txHash: string): Object {
+function getTransactionByHashRequest(id: number | RegExp, txHash: string): Object {
   return {
     jsonrpc: '2.0',
     id,
@@ -239,7 +239,7 @@ function getTransactionByHashRequest(id: number, txHash: string): Object {
   }
 }
 
-function getTransactionByHashResponse(id: number, txHash: string, blockHash: string | null, blockNumber: number | null, from: string, to: string, value: string): Object {
+function getTransactionByHashResponse(id: number | RegExp, txHash: string, blockHash: string | null, blockNumber: number | null, from: string, to: string, value: string): Object {
   return {
     jsonrpc:'2.0',
     id,
@@ -259,7 +259,7 @@ function getTransactionByHashResponse(id: number, txHash: string, blockHash: str
   }
 }
 
-function getBlockNumberRequest(id: number): Object {
+function getBlockNumberRequest(id: number | RegExp): Object {
   return {
     jsonrpc: '2.0',
     id,
@@ -268,7 +268,7 @@ function getBlockNumberRequest(id: number): Object {
   }
 }
 
-function getBlockNumberResponse(id: number, count: string): Object {
+function getBlockNumberResponse(id: number | RegExp, count: string): Object {
   return {
     jsonrpc:'2.0',
     id,
@@ -276,7 +276,7 @@ function getBlockNumberResponse(id: number, count: string): Object {
   }
 }
 
-function getBlockByNumberRequest(id: number, blockNumber: string): Object {
+function getBlockByNumberRequest(id: number | RegExp, blockNumber: string): Object {
   return {
     jsonrpc: '2.0',
     id,
@@ -285,7 +285,7 @@ function getBlockByNumberRequest(id: number, blockNumber: string): Object {
   }
 }
 
-function getBlockByNumberResponse(id: number, blockNumber: string, blockHash: string, txHashes: [string]): Object {
+function getBlockByNumberResponse(id: number | RegExp, blockNumber: string, blockHash: string, txHashes: [string]): Object {
   return {
     jsonrpc:'2.0',
     id,


### PR DESCRIPTION
- Fix getTransactionInfo throwing confusing error: `Cannot read property 'input' of null` when tx is not known to node
- Stop checking gas price during balance requests because it's going to get us rate limited
- Gracefully handle web3 `already known` broadcast error
- Broadcast transactions to blockbook node as backup measure