### PR TITLE
Fix doge range error

### DIFF
--- a/packages/doge-payments/package-lock.json
+++ b/packages/doge-payments/package-lock.json
@@ -490,6 +490,78 @@
         "minimist": "^1.2.0"
       }
     },
+    "@faast/bitcoin-payments": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@faast/bitcoin-payments/-/bitcoin-payments-4.0.0.tgz",
+      "integrity": "sha512-hnJJqBHVr4tmNPtD0nJu2BfZ3oQamifIvPLLLO3lyuDj2ze/H0MTzYiI5mixTfYNjsUecWb0BIrRF2XFeBOZ0A==",
+      "requires": {
+        "@faast/payments-common": "^4.0.0",
+        "@faast/ts-common": "^0.6.0",
+        "bignumber.js": "^9.0.0",
+        "bip174": "^1.0.1",
+        "bip32": "^2.0.5",
+        "bitcoinjs-lib": "^5.2.0",
+        "blockbook-client": "^0.3.11",
+        "bs58": "^4.0.1",
+        "io-ts": "^1.10.4",
+        "lodash": "^4.17.15",
+        "promise-retry": "^1.1.1",
+        "request-promise-native": "^1.0.8"
+      },
+      "dependencies": {
+        "bitcoinjs-lib": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/bitcoinjs-lib/-/bitcoinjs-lib-5.2.0.tgz",
+          "integrity": "sha512-5DcLxGUDejgNBYcieMIUfjORtUeNWl828VWLHJGVKZCb4zIS1oOySTUr0LGmcqJBQgTBz3bGbRQla4FgrdQEIQ==",
+          "requires": {
+            "bech32": "^1.1.2",
+            "bip174": "^2.0.1",
+            "bip32": "^2.0.4",
+            "bip66": "^1.1.0",
+            "bitcoin-ops": "^1.4.0",
+            "bs58check": "^2.0.0",
+            "create-hash": "^1.1.0",
+            "create-hmac": "^1.1.3",
+            "merkle-lib": "^2.0.10",
+            "pushdata-bitcoin": "^1.0.1",
+            "randombytes": "^2.0.1",
+            "tiny-secp256k1": "^1.1.1",
+            "typeforce": "^1.11.3",
+            "varuint-bitcoin": "^1.0.4",
+            "wif": "^2.0.1"
+          },
+          "dependencies": {
+            "bip174": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/bip174/-/bip174-2.0.1.tgz",
+              "integrity": "sha512-i3X26uKJOkDTAalYAp0Er+qGMDhrbbh2o93/xiPyAN2s25KrClSpe3VXo/7mNJoqA5qfko8rLS2l3RWZgYmjKQ=="
+            }
+          }
+        },
+        "blockbook-client": {
+          "version": "0.3.11",
+          "resolved": "https://registry.npmjs.org/blockbook-client/-/blockbook-client-0.3.11.tgz",
+          "integrity": "sha512-34jUs97es0XJ4ITqfu62Yskw6AdQ9Uu70lY1KDWjxHS1ZO5hVYRonXmUYbTAqqMlkIHqEmNKUMiQCHL6V7bgtA==",
+          "requires": {
+            "@faast/ts-common": "^0.6.0",
+            "io-ts": "^1.10.4",
+            "qs": "^6.9.1",
+            "request": "^2.88.0",
+            "request-promise-native": "^1.0.8"
+          }
+        }
+      }
+    },
+    "@faast/payments-common": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@faast/payments-common/-/payments-common-4.0.0.tgz",
+      "integrity": "sha512-S1Gc+AD6ofQDbyNvO6IJJh0GybN6u//41KKpidFdOZJi0IKjW3jQD5DbgIdf1bZEgBF7Me2Ov1Fne/Y7x0hCsg==",
+      "requires": {
+        "@faast/ts-common": "^0.6.0",
+        "bignumber.js": "^9.0.0",
+        "io-ts": "^1.10.4"
+      }
+    },
     "@faast/ts-common": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/@faast/ts-common/-/ts-common-0.6.0.tgz",
@@ -2181,9 +2253,8 @@
       "integrity": "sha512-pef6gxZFztEhaE9RY9HmWVmiIHqCb2OyS4HPKkpc6CIiiOa3Qmuoylxc5P2EkU3w+5eTSifI9SEZC88idAIGow=="
     },
     "bitcoinjs-lib": {
-      "version": "5.1.10",
-      "resolved": "https://registry.npmjs.org/bitcoinjs-lib/-/bitcoinjs-lib-5.1.10.tgz",
-      "integrity": "sha512-CesUqtBtnYc+SOMsYN9jWQWhdohW1MpklUkF7Ukn4HiAyN6yxykG+cIJogfRt6x5xcgH87K1Q+Mnoe/B+du1Iw==",
+      "version": "github:go-faast/bitcoinjs-lib#9323d76267d6da236dc07c88cf00d12ebf341093",
+      "from": "github:go-faast/bitcoinjs-lib#doge",
       "requires": {
         "bech32": "^1.1.2",
         "bip174": "^1.0.1",

--- a/packages/doge-payments/package.json
+++ b/packages/doge-payments/package.json
@@ -81,7 +81,7 @@
     "bignumber.js": "^9.0.0",
     "bip174": "^1.0.1",
     "bip32": "^2.0.5",
-    "bitcoinjs-lib": "^5.1.7",
+    "bitcoinjs-lib": "github:go-faast/bitcoinjs-lib#doge",
     "blockbook-client": "^0.3.5",
     "bs58": "^4.0.1",
     "io-ts": "^1.10.4",

--- a/packages/doge-payments/test/e2e.mainnet.test.ts
+++ b/packages/doge-payments/test/e2e.mainnet.test.ts
@@ -1,3 +1,4 @@
+import { KeyPairDogePayments } from './../src/KeyPairDogePayments';
 import fs from 'fs'
 import path from 'path'
 import { omit } from 'lodash'
@@ -241,6 +242,19 @@ describeAll('e2e mainnet', () => {
     expect(tx.fromIndex).toEqual(10)
     expect(tx.toIndex).toEqual(null)
     expect(tx.inputUtxos).toBeTruthy()
+  })
+
+  it.only('can decode utxo tx with values exceeding 53 bits', async () => {
+    // This utxo has a value of 92M satoshis at vout 13 which causes problems when bitcoinjs tries to decode the tx
+    // because javascript precision breaks down after 53 bits (~90M). verifuint will throw a RangeError
+    // Try to spend any vout to make sure our patched version doesn't throw on these huge values
+    const tx = await payments.createTransaction(0, { address: EXTERNAL_ADDRESS }, '100', { availableUtxos: [{
+      txid: '8e529df6174c31547a1788c5a47ac104453688d7cfd873e4df42d3d1076c6af0',
+      vout: 15,
+      value: '2486366091067',
+      satoshis: 2486366091067,
+      height: '3587546'
+    }]})
   })
 
   it('create sweep transaction to an external address with unconfirmed utxos', async () => {


### PR DESCRIPTION
DOGE transactions spending utxos from txs with very large valued outputs (>90M sat) will fail because they exceed javascripts 53-bit number precision. The bitcoinjs-lib verifuint function will throw a `RangeError: value out of range` to try to warn against this problem. We forked bitcoinjs and removed that maximum which could be problematic if we ever wanted to spend from an output that large. Fortunately we don't forsee owning that much DOGE so this will not affect transactions we actually build.