### PR TITLE
[fix] (erc20) Stop throwing when erc20 tx info amount doesn't match

### DIFF
--- a/packages/ethereum-payments/src/erc20/BaseErc20Payments.ts
+++ b/packages/ethereum-payments/src/erc20/BaseErc20Payments.ts
@@ -296,7 +296,7 @@ export abstract class BaseErc20Payments <Config extends BaseErc20PaymentsConfig>
       if (txReceipt) {
         const actualAmount = this.getErc20TransferLogAmount(txReceipt)
         if (isExecuted && amount !== actualAmount) {
-          throw new Error(
+          this.logger.warn(
             `Transcation ${txid} tried to transfer ${amount} but only ${actualAmount} was actually transferred`
           )
         }


### PR DESCRIPTION
The TUSD token officially has 18 decimal places, however their built in "burn" transfers actually only use 2 decimal places resulting in amount mismatches and an unwanted error. Replacing the error with a warning message should be sufficient