### PR TITLE
[fix] (bitcoinish) Correctly estimate tx size when an address has multiple outputs

### DIFF
--- a/packages/bitcoin-cash-payments/src/BaseBitcoinCashPayments.ts
+++ b/packages/bitcoin-cash-payments/src/BaseBitcoinCashPayments.ts
@@ -14,9 +14,9 @@ import {
   BitcoinCashAddressFormat,
 } from './types'
 import {
-  BITCOIN_SEQUENCE_RBF,
+  BITCOIN_SEQUENCE_RBF, SINGLESIG_ADDRESS_TYPE,
 } from './constants'
-import { isValidAddress, isValidPrivateKey, isValidPublicKey, standardizeAddress, estimateBitcoinCashTxSize } from './helpers'
+import { estimateBitcoinCashTxSize } from './helpers'
 import { BitcoinCashPaymentsUtils } from './BitcoinCashPaymentsUtils'
 
 // tslint:disable-next-line:max-line-length
@@ -76,14 +76,12 @@ export abstract class BaseBitcoinCashPayments<Config extends BaseBitcoinCashPaym
   }
 
   estimateTxSize(inputCount: number, changeOutputCount: number, externalOutputAddresses: string[]): number {
-    const outputCounts = externalOutputAddresses.reduce((outputCounts, address) => {
-      // @ts-ignore
-      outputCounts[address] = 1
-      return outputCounts
-    }, { [AddressType.Legacy]: changeOutputCount })
     return estimateBitcoinCashTxSize(
       { [this.getEstimateTxSizeInputKey()]: inputCount },
-      outputCounts,
+      {
+        ...bitcoinish.countOccurences(externalOutputAddresses),
+        [SINGLESIG_ADDRESS_TYPE]: changeOutputCount,
+      },
       this.networkType,
     )
   }

--- a/packages/bitcoin-payments/src/BaseBitcoinPayments.ts
+++ b/packages/bitcoin-payments/src/BaseBitcoinPayments.ts
@@ -17,7 +17,9 @@ import {
   BITCOIN_SEQUENCE_RBF,
 } from './constants'
 import { isValidAddress, isValidPrivateKey, isValidPublicKey, standardizeAddress, estimateBitcoinTxSize } from './helpers'
-import { BitcoinishPayments, BitcoinishPaymentTx, BitcoinishTxOutput, getBlockcypherFeeRecommendation } from './bitcoinish'
+import {
+  BitcoinishPayments, BitcoinishPaymentTx, BitcoinishTxOutput, countOccurences, getBlockcypherFeeRecommendation,
+} from './bitcoinish'
 
 export abstract class BaseBitcoinPayments<Config extends BaseBitcoinPaymentsConfig> extends BitcoinishPayments<Config> {
 
@@ -65,13 +67,12 @@ export abstract class BaseBitcoinPayments<Config extends BaseBitcoinPaymentsConf
   }
 
   estimateTxSize(inputCount: number, changeOutputCount: number, externalOutputAddresses: string[]): number {
-    const outputCounts = externalOutputAddresses.reduce((outputCounts, address) => {
-      outputCounts[address] = 1
-      return outputCounts
-    }, { [this.addressType]: changeOutputCount })
     return estimateBitcoinTxSize(
       { [this.getEstimateTxSizeInputKey()]: inputCount },
-      outputCounts,
+      {
+        ...countOccurences(externalOutputAddresses),
+        [this.addressType]: changeOutputCount,
+      },
       this.networkType,
     )
   }

--- a/packages/bitcoin-payments/src/bitcoinish/utils.ts
+++ b/packages/bitcoin-payments/src/bitcoinish/utils.ts
@@ -83,6 +83,13 @@ export function sumUtxoValue(utxos: UtxoInfo[], includeUnconfirmed?: boolean): B
   return sumField(filtered, 'value')
 }
 
+export function countOccurences<T extends string[]>(a: T): { [key: string]: number } {
+  return a.reduce((result, element) => {
+    result[element] = (result[element] ?? 0) + 1
+    return result
+  }, {} as { [key: string]: number })
+}
+
 /**
  * Shuffle the utxos for input selection.
  */

--- a/packages/bitcoin-payments/test/HdBitcoinPayments.test.ts
+++ b/packages/bitcoin-payments/test/HdBitcoinPayments.test.ts
@@ -318,6 +318,10 @@ describe('HdBitcoinPayments', () => {
         .toString()
       expect(paymentTx.fee).toBe(expectedFee)
     })
+
+    it('estimateTxSize provides correct estimate when address has multiple external outputs', () => {
+      expect(payments.estimateTxSize(1, 1, [EXTERNAL_ADDRESS, EXTERNAL_ADDRESS, EXTERNAL_ADDRESS])).toBe(211)
+    })
   })
 
   for (let k in accountsByAddressType) {

--- a/packages/doge-payments/src/BaseDogePayments.ts
+++ b/packages/doge-payments/src/BaseDogePayments.ts
@@ -63,14 +63,12 @@ export abstract class BaseDogePayments<Config extends BaseDogePaymentsConfig> ex
   }
 
   estimateTxSize(inputCount: number, changeOutputCount: number, externalOutputAddresses: string[]): number {
-    const outputCounts = externalOutputAddresses.reduce((outputCounts, address) => {
-      // @ts-ignore
-      outputCounts[address] = 1
-      return outputCounts
-    }, { [SINGLESIG_ADDRESS_TYPE]: changeOutputCount })
     return estimateDogeTxSize(
       { [this.getEstimateTxSizeInputKey()]: inputCount },
-      outputCounts,
+      {
+        ...bitcoinish.countOccurences(externalOutputAddresses),
+        [SINGLESIG_ADDRESS_TYPE]: changeOutputCount,
+      },
       this.networkType,
     )
   }

--- a/packages/litecoin-payments/src/BaseLitecoinPayments.ts
+++ b/packages/litecoin-payments/src/BaseLitecoinPayments.ts
@@ -21,7 +21,7 @@ import {
 import {
   LITECOIN_SEQUENCE_RBF,
 } from './constants'
-import { isValidAddress, isValidPrivateKey, isValidPublicKey, standardizeAddress, estimateLitecoinTxSize } from './helpers'
+import { estimateLitecoinTxSize } from './helpers'
 import { LitecoinPaymentsUtils } from './LitecoinPaymentsUtils'
 
 export abstract class BaseLitecoinPayments<Config extends BaseLitecoinPaymentsConfig>
@@ -75,13 +75,12 @@ export abstract class BaseLitecoinPayments<Config extends BaseLitecoinPaymentsCo
   }
 
   estimateTxSize(inputCount: number, changeOutputCount: number, externalOutputAddresses: string[]): number {
-    const outputCounts = externalOutputAddresses.reduce((outputCounts, address) => {
-      outputCounts[address] = 1
-      return outputCounts
-    }, { [this.addressType]: changeOutputCount })
     return estimateLitecoinTxSize(
       { [this.getEstimateTxSizeInputKey()]: inputCount },
-      outputCounts,
+      {
+        ...bitcoinish.countOccurences(externalOutputAddresses),
+        [this.addressType]: changeOutputCount,
+      },
       this.networkType,
     )
   }


### PR DESCRIPTION
The `estimateTxSize` method falsely assumed that each address would have at most one output, since that'd be the most fee efficient way to create a tx. However sometimes creating extra outputs for the same address is desired and that wasn't being accounted for when estimating the size. This resulted in underspending on the fee and confirmation delays.