### PR TITLE
[feat] (bitoinish,common) Support for block balance activity listening

### DIFF
--- a/packages/bitcoin-payments/package-lock.json
+++ b/packages/bitcoin-payments/package-lock.json
@@ -3278,9 +3278,9 @@
       }
     },
     "blockbook-client": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/blockbook-client/-/blockbook-client-0.4.2.tgz",
-      "integrity": "sha512-ZaEPe0CXEuYpFC8bcr//5vJcLc6A8xSDrVLcDXFcJxNjhJGzDPd71sCReJd3v6DrxXMpa12nRHxXH8WOW3fdsA==",
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/blockbook-client/-/blockbook-client-0.4.4.tgz",
+      "integrity": "sha512-eynh92jXYje9SA0EM/F641BBsjxHdO/mXeclkNGtYEm+SffsIJabf9ZxI5lfExoZcYA8RsNmB8IKP+ZSkkyK0w==",
       "requires": {
         "@faast/ts-common": "^0.6.0",
         "io-ts": "^1.10.4",
@@ -9877,9 +9877,9 @@
       }
     },
     "object-inspect": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.10.2.tgz",
-      "integrity": "sha512-gz58rdPpadwztRrPjZE9DZLOABUpTGdcANUgOwBFO1C+HZZhePoP83M65WGDmbpwFYJSWqavbl4SgDn4k8RYTA=="
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.10.3.tgz",
+      "integrity": "sha512-e5mCJlSH7poANfC8z8S9s9S2IN5/4Zb3aZ33f5s8YqoazCFzNLloLU8r5VCG+G7WoqLvAAZoVMcy3tp/3X0Plw=="
     },
     "object-visit": {
       "version": "1.0.1",

--- a/packages/bitcoin-payments/package.json
+++ b/packages/bitcoin-payments/package.json
@@ -82,7 +82,7 @@
     "bip174": "^1.0.1",
     "bip32": "^2.0.5",
     "bitcoinjs-lib": "^5.2.0",
-    "blockbook-client": "^0.4.2",
+    "blockbook-client": "^0.4.4",
     "bs58": "^4.0.1",
     "io-ts": "^1.10.4",
     "lodash": "^4.17.15",

--- a/packages/bitcoin-payments/test/e2e.testnet.test.ts
+++ b/packages/bitcoin-payments/test/e2e.testnet.test.ts
@@ -399,6 +399,19 @@ describeAll('e2e testnet', () => {
         expect(sortAndOmitBalanceActivities(pastActivities))
           .toEqual(sortAndOmitBalanceActivities(recordedBalanceActivities))
       })
+
+      it('can retrieve block activities', async () => {
+        const blockActivities: BalanceActivity[] = []
+        const blockNumber = 1975840
+        await balanceMonitor.retrieveBlockBalanceActivities(blockNumber, (activity) => {
+          blockActivities.push(activity)
+        }, (addresses) => addresses.filter((address) => addressesToWatch.includes(address)))
+        expect(blockActivities.length).toBe(4)
+        for (let activity of blockActivities) {
+          expect(addressesToWatch).toContain(activity.address)
+          expect(activity.confirmationNumber).toBe(blockNumber)
+        }
+      })
     })
   }
 })

--- a/packages/payments-common/src/BalanceMonitor.ts
+++ b/packages/payments-common/src/BalanceMonitor.ts
@@ -3,6 +3,7 @@ import {
   GetBalanceActivityOptions,
   RetrieveBalanceActivitiesResult,
   BalanceActivity,
+  NewBlockCallback,
 } from './types'
 
 /**
@@ -32,6 +33,7 @@ export interface BalanceMonitor {
   destroy(): Promise<void>
 
   /**
+   * Watch for mempool transactions and emit balance activities that apply to the specified addresses
    * @param addresses The addresses to watch for balance activity on
    */
   subscribeAddresses(addresses: string[]): Promise<void>
@@ -71,4 +73,30 @@ export interface BalanceMonitor {
    * @param tx The raw transaction object returned by the network
    */
   txToBalanceActivity(address: string, tx: object): Promise<BalanceActivity | null>
+
+  /**
+   * Watch for confirmed blocks and emit balance activities that apply to the result of the filter
+   * @param filterRelevantAddresses A callback to filter all block addresses to only relevant ones
+   */
+  subscribeNewBlock?: (filterRelevantAddresses: (addresses: string[]) => Promise<string[]>) => Promise<void>
+
+  /**
+   * Add an event listener that is called whenever a new block is confirmed.
+   * @param callbackFn A callback to receive incoming block hash/height
+   */
+  onNewBlock?: (callbackFn: NewBlockCallback) => void
+
+  /**
+   * Retrieve all balanace activities in a given block. The addresses affected by the block will be passed
+   * into the filterRelevantAddresses function and the resulting addresses will be applied to filter out
+   * irrelevant balance activities.
+   * @param block The block number or hash to look up
+   * @param callbackFn A callback for all emitted activities
+   * @param filterRelevantAddresses A callback for filtering what addresses balance activities should be emitted
+   */
+  retrieveBlockBalanceActivities?: (
+    block: number | string,
+    callbackFn: BalanceActivityCallback,
+    filterRelevantAddresses: (addresses: string[]) => string[] | Promise<string[]>,
+  ) => Promise<{ hash: string, height: number }>
 }

--- a/packages/payments-common/src/types.ts
+++ b/packages/payments-common/src/types.ts
@@ -352,6 +352,9 @@ export type GetBalanceActivityOptions = t.TypeOf<typeof GetBalanceActivityOption
 export type BalanceActivityCallback = (ba: BalanceActivity, rawTx?: any) => Promise<void> | void
 export const BalanceActivityCallback = functionT<BalanceActivityCallback>('BalanceActivityCallback')
 
+export type NewBlockCallback = (b: { height: number, hash: string }) => Promise<void> | void
+export const NewBlockCallback = functionT<NewBlockCallback>('NewBlockCallback')
+
 export type FromTo = Pick<
   BaseUnsignedTransaction,
   'fromAddress' | 'fromIndex' | 'fromExtraId' | 'toAddress' | 'toIndex' | 'toExtraId'


### PR DESCRIPTION
3 new optional `BalanceMonitor` methods currently only implemented in BitcoinishBalanceMonitor
- `subscribeNewBlock` - subscribe to new confirmed block hashes
- `onNewBlock` - Set a callback for all new block events
- `retrieveBlockBalanceActivities` - Retrieve balance activities for a certain block and a given address filter
